### PR TITLE
Makes block hashes wrap properly so they don't overflow the viewport …

### DIFF
--- a/www/style.css
+++ b/www/style.css
@@ -1250,7 +1250,7 @@ img.footer_container_content_onion-links_icon {
 }
 
 .block-hash span, .block-stats-table a, .addr-stats-table a, .transaction-box .header a {
-  word-break: break-all;
+  word-wrap: break-word;
 }
 
 


### PR DESCRIPTION
…and are completely visible

![screen shot 2019-02-16 at 15 26 45](https://user-images.githubusercontent.com/29760774/52906977-7ecef700-320c-11e9-94f5-4e73c6a25a7c.png)

vs. 

![screen shot 2019-02-16 at 15 27 36](https://user-images.githubusercontent.com/29760774/52906980-85f60500-320c-11e9-88c9-c1daa5a521c2.png)
