### PR TITLE
Amend example results of fee-estimates to string: decimal

### DIFF
--- a/API.md
+++ b/API.md
@@ -191,7 +191,7 @@ and the value is the estimated feerate (in sat/vB).
 
 The available confirmation targets are 2, 3, 4, 6, 10, 20, 144, 504 and 1008 blocks.
 
-For example: `{ 2: 36.183, 3: 34.841, 4: 34.841, 6: 34.841, 10: 22.164, 20: 9.692, 144: 1, 501: 1, 1008:1 }`
+For example: `{"144":1.027,"20":1.027,"1008":1.027,"6":68.285,"2":87.882,"10":1.027,"3":87.882,"4":87.882,"504":1.027}`
 
 ## Transaction format
 

--- a/API.md
+++ b/API.md
@@ -191,7 +191,7 @@ and the value is the estimated feerate (in sat/vB).
 
 The available confirmation targets are 2, 3, 4, 6, 10, 20, 144, 504 and 1008 blocks.
 
-For example: `{"144":1.027,"20":1.027,"1008":1.027,"6":68.285,"2":87.882,"10":1.027,"3":87.882,"4":87.882,"504":1.027}`
+For example: `{ "2": 87.882, "3": 87.882, "4": 87.882, "6": 68.285, "10": 1.027, "20": 1.027, "144": 1.027, "504": 1.027, "1008": 1.027 }`
 
 ## Transaction format
 


### PR DESCRIPTION
The api itself returns string:decimal pairs but the documentation example shows it as int:decimal.

This brings the documentation in line with the api.

Addresses Issue #87 