### PR TITLE
Light Theme - Assets table row text color update

### DIFF
--- a/client/src/views/block.js
+++ b/client/src/views/block.js
@@ -17,7 +17,7 @@ export default ({ t, block: b, blockStatus: status, blockTxs, openTx, spends, op
       <div className="container">
         { search({ t, klass: 'page-search-bar' }) }
         <div>
-          <h1 className="block-header-title">{t`Block ${formatNumber(b.height)}`}</h1>
+          <h1 className="block-header-title">{t`Block ${(b.height)}`}</h1>
           <div className="block-hash"><span>{b.id}</span>
             { process.browser && <div className="code-button">
               <div className="code-button-btn" role="button" data-clipboardCopy={b.id}></div>

--- a/client/src/views/home.js
+++ b/client/src/views/home.js
@@ -42,7 +42,7 @@ export const recentBlocks = ({ t, blocks, loading, ...S }) => homeLayout(
       { blocks && blocks.map(b =>
         <div className="blocks-table-link-row">
         <a className="blocks-table-row block-data" href={`block/${b.id}`}>
-          <div className="blocks-table-cell highlighted-text" data-label={t`Height`}>{formatNumber(b.height)}</div>
+          <div className="blocks-table-cell highlighted-text" data-label={t`Height`}>{(b.height)}</div>
           <div className="blocks-table-cell" data-label={t`Timestamp`}>{formatTime(b.timestamp, t)}</div>
           <div className="blocks-table-cell" data-label={t`Transactions`}>{formatNumber(b.tx_count)}</div>
           <div className="blocks-table-cell" data-label={t`Size (KB)`}>{formatNumber(b.size/1000)}</div>

--- a/www/light-theme_style.css
+++ b/www/light-theme_style.css
@@ -95,3 +95,10 @@ body.theme-light {
 .theme-light table th, .theme-light table td {
   border-color: #dee2e6 !important;
 }
+
+
+@media only screen and (max-width: 850px) {
+    .theme-light .assets-table-link-row:nth-child(odd)  .assets-table-row {
+       color: #fff !important; 
+     }
+}

--- a/www/light-theme_style.css
+++ b/www/light-theme_style.css
@@ -11,6 +11,10 @@ body.theme-light {
     color: rgba(21, 24, 28, 1) !important;
 }
 
+.theme-light .assets-table-row {
+    color: rgba(21, 24, 28, 1) !important;
+}
+
 .theme-light .jumbotron-fluid {
     background-color: rgba(238, 242, 245, 1) !important;
 }


### PR DESCRIPTION
On - https://blockstream.info/liquid/assets , switch to light mode.
**Current behavior**
The text displays in white. 
**Desired behavior** Match the color with the main block list (black).

See issue created in the link Below:
https://gl.blockstream.com/greenaddress/esplora/-/issues/96