### PR TITLE
Light Theme - Assets Table row text color update

### DIFF
--- a/www/light-theme_style.css
+++ b/www/light-theme_style.css
@@ -11,6 +11,10 @@ body.theme-light {
     color: rgba(21, 24, 28, 1) !important;
 }
 
+.theme-light .assets-table-row {
+    color: rgba(21, 24, 28, 1) !important;
+}
+
 .theme-light .jumbotron-fluid {
     background-color: rgba(238, 242, 245, 1) !important;
 }
@@ -91,3 +95,10 @@ body.theme-light {
 .theme-light table th, .theme-light table td {
   border-color: #dee2e6 !important;
 }
+
+
+@media only screen and (max-width: 850px) {
+    .theme-light .assets-table-link-row:nth-child(odd)  .assets-table-row {
+       color: #fff !important; 
+    }
+} 


### PR DESCRIPTION
Light Theme - Assets Table row text color update for Large Screen and Mobile

Assets list for light theme is unreadable
Steps to reproduce
On - https://blockstream.info/liquid/assets , switch to light mode.

**Current behaviour**
The text displays in white. 

**Desired behaviour**
Match the color with the main block list (black).

**Issue created in the link below**
https://gl.blockstream.com/greenaddress/esplora/-/issues/96