### PR TITLE
Improved numeric spacing

### DIFF
--- a/client/src/views/block.js
+++ b/client/src/views/block.js
@@ -17,7 +17,7 @@ export default ({ t, block: b, blockStatus: status, blockTxs, openTx, spends, op
       <div className="container">
         { search({ t, klass: 'page-search-bar' }) }
         <div>
-          <h1 className="block-header-title">{t`Block ${formatNumber(b.height)}`}</h1>
+          <h1 className="block-header-title">{t`Block ${b.height}`}</h1>
           <div className="block-hash"><span>{b.id}</span>
             { process.browser && <div className="code-button">
               <div className="code-button-btn" role="button" data-clipboardCopy={b.id}></div>
@@ -54,7 +54,7 @@ export default ({ t, block: b, blockStatus: status, blockTxs, openTx, spends, op
       <div className="stats-table">
         <div>
           <div>{t`Height`}</div>
-          <div><a href={`block/${b.id}`}>{formatNumber(b.height)}</a></div>
+          <div><a href={`block/${b.id}`}>{b.height}</a></div>
         </div>
         <div>
           <div>{t`Status`}</div>
@@ -62,7 +62,7 @@ export default ({ t, block: b, blockStatus: status, blockTxs, openTx, spends, op
         </div>
         <div>
           <div>{t`Timestamp`}</div>
-          <div>{formatTime(b.timestamp, t)}</div>
+          <div>{formatTime(b.timestamp)}</div>
         </div>
         <div>
           <div>{t`Size`}</div>

--- a/client/src/views/home.js
+++ b/client/src/views/home.js
@@ -34,7 +34,7 @@ export const recentBlocks = ({ t, blocks, loading, ...S }) => homeLayout(
     <div className="blocks-table">
       <div className="blocks-table-row header">
         <div className="blocks-table-cell">{t`Height`}</div>
-        <div className="blocks-table-cell">{t`Timestamp`}</div>
+        <div className="blocks-table-cell">{process.browser ? t`Timestamp` : t`Timestamp (UTC)`}</div>
         <div className="blocks-table-cell">{t`Transactions`}</div>
         <div className="blocks-table-cell">{t`Size (KB)`}</div>
         <div className="blocks-table-cell">{t`Weight (KWU)`}</div>
@@ -42,8 +42,8 @@ export const recentBlocks = ({ t, blocks, loading, ...S }) => homeLayout(
       { blocks && blocks.map(b =>
         <div className="blocks-table-link-row">
         <a className="blocks-table-row block-data" href={`block/${b.id}`}>
-          <div className="blocks-table-cell highlighted-text" data-label={t`Height`}>{formatNumber(b.height)}</div>
-          <div className="blocks-table-cell" data-label={t`Timestamp`}>{formatTime(b.timestamp, t)}</div>
+          <div className="blocks-table-cell highlighted-text" data-label={t`Height`}>{b.height}</div>
+          <div className="blocks-table-cell" data-label={t`Timestamp`}>{formatTime(b.timestamp, false)}</div>
           <div className="blocks-table-cell" data-label={t`Transactions`}>{formatNumber(b.tx_count)}</div>
           <div className="blocks-table-cell" data-label={t`Size (KB)`}>{formatNumber(b.size/1000)}</div>
           <div className="blocks-table-cell" data-label={t`Weight (KWU)`}>{formatNumber(b.weight/1000)}</div>

--- a/client/src/views/tx-vout.js
+++ b/client/src/views/tx-vout.js
@@ -74,7 +74,7 @@ const standard = (vout, { isOpen, spend, t, ...S }) => layout(
           !spend ? t`Loading...`
           : spend.spent ? <span>
             {t`Spent by`} <a href={`tx/${spend.txid}?input:${spend.vin}`} className="mono">{`${spend.txid}:${spend.vin}`}</a> {' '}
-            { spend.status.confirmed ? <span>{t`in block`} <a href={`block/${spend.status.block_hash}`}>#{formatNumber(spend.status.block_height)}</a></span>
+            { spend.status.confirmed ? <span>{t`in block`} <a href={`block/${spend.status.block_hash}`}>#{spend.status.block_height}</a></span>
                                      : `(${t`unconfirmed`})` }
           </span>
           : t`Unspent`

--- a/client/src/views/tx.js
+++ b/client/src/views/tx.js
@@ -104,11 +104,11 @@ const txHeader = (tx, { tipHeight, mempool, feeEst, t
       </div>
     , <div>
         <div>{t`Block height`}</div>
-        <div>{formatNumber(tx.status.block_height)}</div>
+        <div>{tx.status.block_height}</div>
       </div>
     , <div>
         <div>{t`Block timestamp`}</div>
-        <div>{formatTime(tx.status.block_time, t)}</div>
+        <div>{formatTime(tx.status.block_time)}</div>
       </div>
     ]}
 

--- a/client/src/views/util.js
+++ b/client/src/views/util.js
@@ -8,8 +8,8 @@ const DEFAULT_PRECISION = 0
 
 const pad = n => n < 10 ? '0'+n : n
 
-const formatTimezone = unix => {
-  const tzOffset = new Date(unix*1000).getTimezoneOffset() * -1;
+const formatTimezone = time => {
+  const tzOffset = time.getTimezoneOffset() * -1;
   return tzOffset == 0 ? 'UTC' : 'GMT ' + (tzOffset < 0 ? '' : '+') + (tzOffset/60)
 }
 
@@ -18,7 +18,7 @@ export const formatTime = (unix, with_tz = true) => {
 
   return `${time.getFullYear()}-${pad(time.getMonth() + 1)}-${pad(time.getDate())}`
        + ` ${pad(time.getHours())}:${pad(time.getMinutes())}:${pad(time.getSeconds())}`
-       + (with_tz ? ' ' +formatTimezone(unix) : '')
+       + (with_tz ? ' ' + formatTimezone(time) : '')
 }
 
 export const formatSat = (sats, label=nativeAssetLabel) => `${formatNumber(sat2btc(sats))} ${label}`

--- a/client/src/views/util.js
+++ b/client/src/views/util.js
@@ -8,13 +8,17 @@ const DEFAULT_PRECISION = 0
 
 const pad = n => n < 10 ? '0'+n : n
 
-export const formatTime = unix => {
+const formatTimezone = unix => {
+  const tzOffset = new Date(unix*1000).getTimezoneOffset() * -1;
+  return tzOffset == 0 ? 'UTC' : 'GMT ' + (tzOffset < 0 ? '' : '+') + (tzOffset/60)
+}
+
+export const formatTime = (unix, with_tz = true) => {
   const time = new Date(unix*1000)
-      , tzOffset = time.getTimezoneOffset() * -1
 
   return `${time.getFullYear()}-${pad(time.getMonth() + 1)}-${pad(time.getDate())}`
        + ` ${pad(time.getHours())}:${pad(time.getMinutes())}:${pad(time.getSeconds())}`
-       + ` GMT${tzOffset == 0 ? '' : (tzOffset < 0 ? '' : '+') + (tzOffset/60)}`
+       + (with_tz ? ' ' +formatTimezone(unix) : '')
 }
 
 export const formatSat = (sats, label=nativeAssetLabel) => `${formatNumber(sat2btc(sats))} ${label}`


### PR DESCRIPTION
**Improved numeric spacing**

Issue created by Allen
https://gl.blockstream.com/greenaddress/esplora/-/issues/99

- Remove Spacing and Commas from Main Block list
- Timestamp - relabel the header as the displayed timezone, e.g. TIMESTAMP (GMT -5), and each item should only display the date/time.

Transaction details:

* always display block height without a space or comma.
* amounts, always display 8 full decimals (unless 0).

