### PR TITLE
doc: fix esplora's docker image name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ docker build -t esplora .
 ```
 docker run -p 50001:50001 -p 8080:80 \
            --volume $PWD/data_bitcoin_mainnet:/data \
-           --rm -i -t esplora \
+           --rm -i -t blockstream/esplora \
            bash -c "/srv/explorer/run.sh bitcoin-mainnet explorer"
 ```
 
@@ -157,7 +157,7 @@ docker run -p 50001:50001 -p 8080:80 \
 ```
 docker run -p 50001:50001 -p 8082:80 \
            --volume $PWD/data_liquid_mainnet:/data \
-           --rm -i -t esplora \
+           --rm -i -t blockstream/esplora \
            bash -c "/srv/explorer/run.sh liquid-mainnet explorer"
 ```
 
@@ -166,7 +166,7 @@ docker run -p 50001:50001 -p 8082:80 \
 ```
 docker run -p 50001:50001 -p 8084:80 \
            --volume $PWD/data_bitcoin_testnet:/data \
-           --rm -i -t esplora \
+           --rm -i -t blockstream/esplora \
            bash -c "/srv/explorer/run.sh bitcoin-testnet explorer"
 ```
 
@@ -175,7 +175,7 @@ docker run -p 50001:50001 -p 8084:80 \
 ```
 docker run -p 50001:50001 -p 8092:80 \
            --volume $PWD/data_liquid_regtest:/data \
-           --rm -i -t esplora \
+           --rm -i -t blockstream/esplora \
            bash -c "/srv/explorer/run.sh liquid-regtest explorer"
 ```
 
@@ -184,7 +184,7 @@ docker run -p 50001:50001 -p 8092:80 \
 ```
 docker run -p 50001:50001 -p 8094:80 \
            --volume $PWD/data_bitcoin_regtest:/data \
-           --rm -i -t esplora \
+           --rm -i -t blockstream/esplora \
            bash -c "/srv/explorer/run.sh bitcoin-regtest explorer"
 ```
 


### PR DESCRIPTION
Esplora's docker image is available at `blockstream/esplora`