### PR TITLE
UI Bug - Confidential Addresses QR fixed

### DIFF
--- a/www/style.css
+++ b/www/style.css
@@ -1044,6 +1044,8 @@ body > .container, .navbar > .container, .jumbotron-fluid > .container, .content
   text-transform: none;
 }
 
+.address-qr-code { width: 182px; }
+
 
 /* START FOOTER */
 .explorer-container > .footer {
@@ -1552,7 +1554,6 @@ body::after{
   }
 }
 
-
 @media only screen and (max-width: 850px) {
 
     /* blocks table */
@@ -1675,6 +1676,7 @@ body::after{
   margin: 0;
   padding: 0;
 }
+
 }
 
 @media only screen and (max-width: 825px) {
@@ -1713,7 +1715,10 @@ body::after{
   }
 }
 
-@media only screen and (max-width: 600px) {
+@media only screen and (max-width: 575.98px) {
+  .jumbotron-fluid{
+    height: auto;
+  }
   .address-qr-code {
     display: block;
     margin: 0 auto;


### PR DESCRIPTION
**UI bug - Confidential Addresses Qr codes step over the header container #272**

- The Qr code for confidential addresses is larger and steps over the colored container, into the darker background

- Example address

 https://blockstream.info/liquid/address/VJLCpZ8hvvCcmwz8doVqrd3bWRYJseXs5UykvNDGrXK175ovdNYzdQhzCkZz1Y5uc4KYmuNCgNKUDakx

**See Issue link below**
[Ticket Link on Github](https://github.com/Blockstream/esplora/issues/272)