### PR TITLE
Disable pegin validation to workaround mainchain sync delay

### DIFF
--- a/contrib/liquid-mainnet-explorer.conf.in
+++ b/contrib/liquid-mainnet-explorer.conf.in
@@ -2,6 +2,7 @@ server=1
 peerbloomfilters=0
 enforcenodebloom=1
 disablewallet=1
+validatepegin=0
 mainchainrpccookiefile=/data/bitcoin/.cookie
 listenonion=1
 listen=0


### PR DESCRIPTION
- elementsd will mark liquid blocks as invalid, if they contain pegins
that reference mainchain blocks that haven't synced
- elementsd does not (yet) recover by itself, see

https://github.com/ElementsProject/elements/issues/891

- when elementsd can automatically revalidate blocks, we
should revert this commit