### PR TITLE
Makes the container work in regtest mode for bitcoind

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -240,6 +240,7 @@ chmod +x /etc/service/${DAEMON}/run
 if [ "${NETWORK}" == "regtest" ]; then
     if [ "${DAEMON}" != "liquid" ]; then
         /srv/explorer/bitcoin/bin/bitcoind -conf=/data/.bitcoin.conf -datadir=/data/bitcoin -daemon -regtest
+        cli createwallet -rpcwait "default"
     else
         /srv/explorer/$DAEMON/bin/${DAEMON}d -conf=/data/.$DAEMON.conf -datadir=/data/$DAEMON -daemon
     fi


### PR DESCRIPTION
I was struggling to get the container run in regtest mode, despite following the instructions.

```
docker run -p 50001:50001 -p 8094:80 \
           --volume $PWD/data_bitcoin_regtest:/data \
           --rm -i -t esplora \
           bash -c "/srv/explorer/run.sh bitcoin-regtest explorer"
```

As it turns out, the [`bitcoin.conf` for regtest](https://github.com/Blockstream/esplora/blob/7c0f7d03cfc9f221eb54156ee0c29e9f1c9d069a/contrib/bitcoin-regtest-explorer.conf.in) does *not* have `disablewallet=1` unlike main and testnet. I also saw that the regtest mode generates 100 blocks to give the chain some history to work with.

In order for `cli -rpcwait getnewaddress` and `cli generatetoaddress 100 ${address}` to work, we need to first create a wallet, since `bitcoind` doesn't do this automatically anymore.

This commit creates a wallet with the name `default` prior to running the aforementioned commands.