### PR TITLE
devops/tasks#1361: update prometheus federation

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -133,7 +133,6 @@ plan:
         -var "regions=$REGIONS"
         -var "zones=$ZONES"
         -var "ssl_certs=$SSL_CERTS"
-        -var "opsgenie_api_key=$OPSGENIE_API_KEY"
         -var "image_source_project=$IMAGE_SOURCE_PROJECT"
         -input=false)
 
@@ -160,7 +159,6 @@ plan_main:
         -var "regions=$REGIONS"
         -var "zones=$ZONES"
         -var "ssl_certs=$SSL_CERTS"
-        -var "opsgenie_api_key=$OPSGENIE_API_KEY"
         -var "image_source_project=$IMAGE_SOURCE_PROJECT"
         -input=false)
 
@@ -188,7 +186,6 @@ deploy_main:
         -var "regions=$REGIONS"
         -var "zones=$ZONES"
         -var "ssl_certs=$SSL_CERTS"
-        -var "opsgenie_api_key=$OPSGENIE_API_KEY"
         -var "image_source_project=$IMAGE_SOURCE_PROJECT"
         -input=false -auto-approve)
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -30,13 +30,12 @@ module "prometheus" {
   region                     = var.regions[0]
   instances                  = 1
   machine_type               = var.instance_type[2]
-  retention                  = "31d"
+  retention                  = "7d"
   project                    = var.project
   docker_tag                 = var.docker_tag_prometheus
   docker_tag_node_exporter   = var.docker_tag_node_exporter
   allowed_source_ip          = var.prometheus_allowed_source_ip
   prometheus_service_account = terraform.workspace != "main" ? data.terraform_remote_state.main.outputs.prometheus_service_account : ""
-  opsgenie_api_key           = var.opsgenie_api_key
 
   create_resources = local.create_main
 }

--- a/terraform/modules/prometheus/cloud-init/prometheus.yml
+++ b/terraform/modules/prometheus/cloud-init/prometheus.yml
@@ -9,69 +9,6 @@ users:
     uid: 2000
 
 write_files:
-  - path: /home/bs/prometheus/alertmanager.yml
-    permissions: 0644
-    owner: root
-    content: |
-        route:
-         group_by: [cluster]
-         # If an alert isn't caught by a route, send it to the pager.
-         receiver: team-pager
-         routes:
-          # Send severity=page alerts to the pager.
-          - match:
-              severity: page
-            receiver: team-pager
-
-        receivers:
-          - name: team-pager
-            opsgenie_configs:
-            - api_key: ${opsgenie_api_key}
-              tags: esplora
-              responders:
-              - type: team
-                name: SecOps
-
-  - path: /home/bs/prometheus/rules/alerts.yml
-    permissions: 0644
-    owner: root
-    content: |
-        groups:
-          - name: node
-            rules:
-            - alert: NoHostsInNetwork
-              expr: sum by (name) (up{name=~".+"}) == 0
-              for: 1m
-              labels:
-                severity: page
-              annotations:
-                summary: No hosts in network {{ $labels.name }}, production traffic impacted!
-                description: There are currently no hosts up in the network {{ $labels.name }}, verify the instance groups. https://wiki.blockstream.io/OpsPlaybooks/Esplora-Runbooks#NoHostsInNetwork
-            - alert: NoHostsInNetworkBitcoinMainnet
-              expr: absent(up{name="bitcoin-mainnet"})
-              for: 1m
-              labels:
-                severity: page
-              annotations:
-                summary: No hosts in network {{ $labels.name }}, production traffic impacted!
-                description: There are currently no hosts up in the network {{ $labels.name }}, verify the instance group. https://wiki.blockstream.io/OpsPlaybooks/Esplora-Runbooks#NoHostsInNetworkBitcoinMainnet
-            - alert: NoHostsInNetworkBitcoinTestnet
-              expr: absent(up{name="bitcoin-testnet"})
-              for: 1m
-              labels:
-                severity: page
-              annotations:
-                summary: No hosts in network {{ $labels.name }}, production traffic impacted!
-                description: There are currently no hosts up in the network {{ $labels.name }}, verify the instance group. https://wiki.blockstream.io/OpsPlaybooks/Esplora-Runbooks#NoHostsInNetworkBitcoinTestnet
-            - alert: NoHostsInNetworkLiquidMainnet
-              expr: absent(up{name="liquid-mainnet"})
-              for: 1m
-              labels:
-                severity: page
-              annotations:
-                summary: No hosts in network {{ $labels.name }}, production traffic impacted!
-                description: There are currently no hosts up in the network {{ $labels.name }}, verify the instance group. https://wiki.blockstream.io/OpsPlaybooks/Esplora-Runbooks#NoHostsInNetworkLiquidMainnet
-
   - path: /home/bs/prometheus/prometheus.yml
     permissions: 0644
     owner: root
@@ -82,18 +19,8 @@ write_files:
           external_labels:
             project: green-address-explorer
 
-        rule_files:
-          - /config/rules/alerts.yml
-
-        alerting:
-          alertmanagers:
-          - scheme: http
-            static_configs:
-            - targets:
-              - "127.0.0.1:9093"
-
         scrape_configs:
-        - job_name: prometheus
+        - job_name: esplora-metrics
           relabel_configs:
             - source_labels:
               - '__meta_gce_label_network'
@@ -107,351 +34,120 @@ write_files:
           gce_sd_configs:
             - project: green-address-explorer
               zone: asia-northeast1-a
-              filter: (labels.type = "prometheus")
               port: 9100
             - project: green-address-explorer
               zone: asia-northeast1-b
-              filter: (labels.type = "prometheus")
               port: 9100
             - project: green-address-explorer
               zone: asia-northeast1-c
-              filter: (labels.type = "prometheus")
               port: 9100
             - project: green-address-explorer
               zone: europe-west4-a
-              filter: (labels.type = "prometheus")
               port: 9100
             - project: green-address-explorer
               zone: europe-west4-b
-              filter: (labels.type = "prometheus")
               port: 9100
             - project: green-address-explorer
               zone: europe-west4-c
-              filter: (labels.type = "prometheus")
               port: 9100
             - project: green-address-explorer
               zone: us-central1-a
-              filter: (labels.type = "prometheus")
               port: 9100
             - project: green-address-explorer
               zone: us-central1-b
-              filter: (labels.type = "prometheus")
               port: 9100
             - project: green-address-explorer
               zone: us-central1-c
-              filter: (labels.type = "prometheus")
               port: 9100
             - project: green-address-explorer
               zone: us-central1-f
-              filter: (labels.type = "prometheus")
               port: 9100
             - project: green-address-explorer
               zone: us-east1-d
-              filter: (labels.type = "prometheus")
               port: 9100
             - project: green-address-explorer
               zone: us-east1-b
-              filter: (labels.type = "prometheus")
               port: 9100
             - project: green-address-explorer
               zone: us-east1-c
-              filter: (labels.type = "prometheus")
-              port: 9100
-        - job_name: tor
-          relabel_configs:
-            - source_labels:
-              - '__meta_gce_label_network'
-              target_label: 'network'
-            - source_labels:
-              - '__meta_gce_label_name'
-              target_label: 'name'
-            - source_labels:
-              - '__meta_gce_instance_name'
-              target_label: 'instance_name'
-          gce_sd_configs:
-            - project: green-address-explorer
-              zone: asia-northeast1-a
-              filter: (labels.type = "tor")
-              port: 9100
-            - project: green-address-explorer
-              zone: asia-northeast1-b
-              filter: (labels.type = "tor")
-              port: 9100
-            - project: green-address-explorer
-              zone: asia-northeast1-c
-              filter: (labels.type = "tor")
-              port: 9100
-            - project: green-address-explorer
-              zone: europe-west4-a
-              filter: (labels.type = "tor")
-              port: 9100
-            - project: green-address-explorer
-              zone: europe-west4-b
-              filter: (labels.type = "tor")
-              port: 9100
-            - project: green-address-explorer
-              zone: europe-west4-c
-              filter: (labels.type = "tor")
-              port: 9100
-            - project: green-address-explorer
-              zone: us-central1-a
-              filter: (labels.type = "tor")
-              port: 9100
-            - project: green-address-explorer
-              zone: us-central1-b
-              filter: (labels.type = "tor")
-              port: 9100
-            - project: green-address-explorer
-              zone: us-central1-c
-              filter: (labels.type = "tor")
-              port: 9100
-            - project: green-address-explorer
-              zone: us-central1-f
-              filter: (labels.type = "tor")
-              port: 9100
-            - project: green-address-explorer
-              zone: us-east1-d
-              filter: (labels.type = "tor")
-              port: 9100
-            - project: green-address-explorer
-              zone: us-east1-b
-              filter: (labels.type = "tor")
-              port: 9100
-            - project: green-address-explorer
-              zone: us-east1-c
-              filter: (labels.type = "tor")
-              port: 9100
-        - job_name: http-tor
-          relabel_configs:
-            - source_labels:
-              - '__meta_gce_label_network'
-              target_label: 'network'
-            - source_labels:
-              - '__meta_gce_label_name'
-              target_label: 'name'
-            - source_labels:
-              - '__meta_gce_instance_name'
-              target_label: 'instance_name'
-          gce_sd_configs:
-            - project: green-address-explorer
-              zone: asia-northeast1-a
-              filter: (labels.type = "http-tor")
-              port: 9100
-            - project: green-address-explorer
-              zone: asia-northeast1-b
-              filter: (labels.type = "http-tor")
-              port: 9100
-            - project: green-address-explorer
-              zone: asia-northeast1-c
-              filter: (labels.type = "http-tor")
-              port: 9100
-            - project: green-address-explorer
-              zone: europe-west4-a
-              filter: (labels.type = "http-tor")
-              port: 9100
-            - project: green-address-explorer
-              zone: europe-west4-b
-              filter: (labels.type = "http-tor")
-              port: 9100
-            - project: green-address-explorer
-              zone: europe-west4-c
-              filter: (labels.type = "http-tor")
-              port: 9100
-            - project: green-address-explorer
-              zone: us-central1-a
-              filter: (labels.type = "http-tor")
-              port: 9100
-            - project: green-address-explorer
-              zone: us-central1-b
-              filter: (labels.type = "http-tor")
-              port: 9100
-            - project: green-address-explorer
-              zone: us-central1-c
-              filter: (labels.type = "http-tor")
-              port: 9100
-            - project: green-address-explorer
-              zone: us-central1-f
-              filter: (labels.type = "http-tor")
-              port: 9100
-            - project: green-address-explorer
-              zone: us-east1-d
-              filter: (labels.type = "http-tor")
-              port: 9100
-            - project: green-address-explorer
-              zone: us-east1-b
-              filter: (labels.type = "http-tor")
-              port: 9100
-            - project: green-address-explorer
-              zone: us-east1-c
-              filter: (labels.type = "http-tor")
-              port: 9100
-        - job_name: explorer
-          relabel_configs:
-            - source_labels:
-              - '__meta_gce_label_network'
-              target_label: 'network'
-            - source_labels:
-              - '__meta_gce_label_name'
-              target_label: 'name'
-            - source_labels:
-              - '__meta_gce_instance_name'
-              target_label: 'instance_name'
-          gce_sd_configs:
-            - project: green-address-explorer
-              zone: asia-northeast1-a
-              filter: (labels.type = "explorer")
-              port: 4224
-            - project: green-address-explorer
-              zone: asia-northeast1-b
-              filter: (labels.type = "explorer")
-              port: 4224
-            - project: green-address-explorer
-              zone: asia-northeast1-c
-              filter: (labels.type = "explorer")
-              port: 4224
-            - project: green-address-explorer
-              zone: europe-west4-a
-              filter: (labels.type = "explorer")
-              port: 4224
-            - project: green-address-explorer
-              zone: europe-west4-b
-              filter: (labels.type = "explorer")
-              port: 4224
-            - project: green-address-explorer
-              zone: europe-west4-c
-              filter: (labels.type = "explorer")
-              port: 4224
-            - project: green-address-explorer
-              zone: us-central1-a
-              filter: (labels.type = "explorer")
-              port: 4224
-            - project: green-address-explorer
-              zone: us-central1-b
-              filter: (labels.type = "explorer")
-              port: 4224
-            - project: green-address-explorer
-              zone: us-central1-c
-              filter: (labels.type = "explorer")
-              port: 4224
-            - project: green-address-explorer
-              zone: us-central1-f
-              filter: (labels.type = "explorer")
-              port: 4224
-            - project: green-address-explorer
-              zone: us-east1-d
-              filter: (labels.type = "explorer")
-              port: 4224
-            - project: green-address-explorer
-              zone: us-east1-b
-              filter: (labels.type = "explorer")
-              port: 4224
-            - project: green-address-explorer
-              zone: us-east1-c
-              filter: (labels.type = "explorer")
-              port: 4224
-            - project: green-address-explorer
-              zone: asia-northeast1-a
-              filter: (labels.type = "explorer")
-              port: 9100
-            - project: green-address-explorer
-              zone: asia-northeast1-b
-              filter: (labels.type = "explorer")
-              port: 9100
-            - project: green-address-explorer
-              zone: asia-northeast1-c
-              filter: (labels.type = "explorer")
-              port: 9100
-            - project: green-address-explorer
-              zone: europe-west4-a
-              filter: (labels.type = "explorer")
-              port: 9100
-            - project: green-address-explorer
-              zone: europe-west4-b
-              filter: (labels.type = "explorer")
-              port: 9100
-            - project: green-address-explorer
-              zone: europe-west4-c
-              filter: (labels.type = "explorer")
-              port: 9100
-            - project: green-address-explorer
-              zone: us-central1-a
-              filter: (labels.type = "explorer")
-              port: 9100
-            - project: green-address-explorer
-              zone: us-central1-b
-              filter: (labels.type = "explorer")
-              port: 9100
-            - project: green-address-explorer
-              zone: us-central1-c
-              filter: (labels.type = "explorer")
-              port: 9100
-            - project: green-address-explorer
-              zone: us-central1-f
-              filter: (labels.type = "explorer")
-              port: 9100
-            - project: green-address-explorer
-              zone: us-east1-d
-              filter: (labels.type = "explorer")
-              port: 9100
-            - project: green-address-explorer
-              zone: us-east1-b
-              filter: (labels.type = "explorer")
-              port: 9100
-            - project: green-address-explorer
-              zone: us-east1-c
-              filter: (labels.type = "explorer")
               port: 9100
             - project: green-address-explorer
               zone: asia-northeast1-a
-              filter: (labels.type = "explorer")
+              port: 4224
+            - project: green-address-explorer
+              zone: asia-northeast1-b
+              port: 4224
+            - project: green-address-explorer
+              zone: asia-northeast1-c
+              port: 4224
+            - project: green-address-explorer
+              zone: europe-west4-a
+              port: 4224
+            - project: green-address-explorer
+              zone: europe-west4-b
+              port: 4224
+            - project: green-address-explorer
+              zone: europe-west4-c
+              port: 4224
+            - project: green-address-explorer
+              zone: us-central1-a
+              port: 4224
+            - project: green-address-explorer
+              zone: us-central1-b
+              port: 4224
+            - project: green-address-explorer
+              zone: us-central1-c
+              port: 4224
+            - project: green-address-explorer
+              zone: us-central1-f
+              port: 4224
+            - project: green-address-explorer
+              zone: us-east1-d
+              port: 4224
+            - project: green-address-explorer
+              zone: us-east1-b
+              port: 4224
+            - project: green-address-explorer
+              zone: us-east1-c
+              port: 4224
+            - project: green-address-explorer
+              zone: asia-northeast1-a
               port: 9256
             - project: green-address-explorer
               zone: asia-northeast1-b
-              filter: (labels.type = "explorer")
               port: 9256
             - project: green-address-explorer
               zone: asia-northeast1-c
-              filter: (labels.type = "explorer")
               port: 9256
             - project: green-address-explorer
               zone: europe-west4-a
-              filter: (labels.type = "explorer")
               port: 9256
             - project: green-address-explorer
               zone: europe-west4-b
-              filter: (labels.type = "explorer")
               port: 9256
             - project: green-address-explorer
               zone: europe-west4-c
-              filter: (labels.type = "explorer")
               port: 9256
             - project: green-address-explorer
               zone: us-central1-a
-              filter: (labels.type = "explorer")
               port: 9256
             - project: green-address-explorer
               zone: us-central1-b
-              filter: (labels.type = "explorer")
               port: 9256
             - project: green-address-explorer
               zone: us-central1-c
-              filter: (labels.type = "explorer")
               port: 9256
             - project: green-address-explorer
               zone: us-central1-f
-              filter: (labels.type = "explorer")
               port: 9256
             - project: green-address-explorer
               zone: us-east1-d
-              filter: (labels.type = "explorer")
               port: 9256
             - project: green-address-explorer
               zone: us-east1-b
-              filter: (labels.type = "explorer")
               port: 9256
             - project: green-address-explorer
               zone: us-east1-c
-              filter: (labels.type = "explorer")
               port: 9256
 
   - path: /etc/systemd/system/prometheus.service
@@ -488,37 +184,7 @@ write_files:
 
         [Install]
         WantedBy=multi-user.target
-  - path: /etc/systemd/system/alertmanager.service
-    permissions: 0644
-    owner: root
-    content: |
-        [Unit]
-        Description=alertmanager-server instance
-        Wants=gcr-online.target docker.service
-        After=gcr-online.service docker.service
-
-        [Service]
-        Restart=always
-        RestartSec=1
-        Environment=HOME=/home/bs
-        ExecStartPre=/usr/bin/docker-credential-gcr configure-docker
-        ExecStartPre=/usr/bin/docker pull ${docker_tag}
-        ExecStartPre=/sbin/iptables -A INPUT -m tcp -p tcp --dport 9093 -j ACCEPT
-        ExecStart=/usr/bin/docker run \
-            --log-driver=gcplogs \
-            --network=host \
-            -v /mnt/disks/data:/data:rw \
-            -v /home/bs/prometheus:/config:ro \
-            --read-only \
-            --name alertmanager \
-            --entrypoint=/bin/alertmanager \
-            "${docker_tag}" --config.file=/config/alertmanager.yml
-        ExecStop=/usr/bin/docker stop alertmanager
-        ExecStopPost=/usr/bin/docker rm alertmanager
-        ExecStopPost=/sbin/iptables -D INPUT -m tcp -p tcp --dport 9093 -j ACCEPT
-
-        [Install]
-        WantedBy=multi-user.target
+        
   - path: /etc/systemd/system/node-exporter.service
     permissions: 0644
     owner: root
@@ -557,9 +223,5 @@ runcmd:
   - /bin/mkdir -p /mnt/disks/data/metrics
   - /bin/chown nobody:nobody /mnt/disks/data/metrics
   - systemctl daemon-reload
-  - systemctl start prometheus.service
-  - systemctl enable prometheus.service
-  - systemctl start alertmanager.service
-  - systemctl enable alertmanager.service
-  - systemctl start node-exporter.service
-  - systemctl enable node-exporter.service
+  - systemctl enable --now prometheus.service
+  - systemctl enable --now node-exporter.service

--- a/terraform/modules/prometheus/data.tf
+++ b/terraform/modules/prometheus/data.tf
@@ -12,7 +12,6 @@ data "template_cloudinit_config" "prometheus" {
       docker_tag               = var.docker_tag
       docker_tag_node_exporter = var.docker_tag_node_exporter
       retention                = var.retention
-      opsgenie_api_key         = var.opsgenie_api_key
     })
   }
 }

--- a/terraform/modules/prometheus/main.tf
+++ b/terraform/modules/prometheus/main.tf
@@ -53,7 +53,7 @@ resource "google_compute_instance" "prometheus-server" {
 
   boot_disk {
     initialize_params {
-      size  = "10"
+      size  = "20"
       image = var.image
     }
   }

--- a/terraform/modules/prometheus/variables.tf
+++ b/terraform/modules/prometheus/variables.tf
@@ -64,8 +64,3 @@ variable "prometheus_service_account" {
   type    = string
   default = ""
 }
-
-variable "opsgenie_api_key" {
-  type        = string
-  description = "Add new Prometheus integration to opsgenie, use resulting API key here"
-}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -108,17 +108,15 @@ variable "docker_tag_nginx" {
 variable "docker_tag_node_exporter" {
   type = string
 
-  # docker inspect --format='{{index .RepoDigests 0}}' prom/node-exporter:v0.16.0
-
-  default = "prom/node-exporter@sha256:b630fb29d99b3483c73a2a7db5fc01a967392a3d7ad754c8eccf9f4a67e7ee31"
+  # docker inspect --format='{{index .RepoDigests 0}}' prom/node-exporter:v1.2.2
+  default = "prom/node-exporter@sha256:a990408ed288669bbad5b5b374fe1584e54825cde4a911c1a3d6301a907a030c"
 }
 
 variable "docker_tag_process_exporter" {
   type = string
 
-  # docker inspect --format='{{index .RepoDigests 0}}' ncabatoff/process-exporter:0.7.1
-
-  default = "ncabatoff/process-exporter@sha256:8daeaa3b5352dc64f5a3d438a1dad5f5c6ff8e468fcb7e50fb0c3f2e8f1b3bfd"
+  # docker inspect --format='{{index .RepoDigests 0}}' ncabatoff/process-exporter:0.7.4
+  default = "ncabatoff/process-exporter@sha256:80f89e0c882cb3bba2fa577e090198bc60127b40e52c65443a657637fc24b0bd"
 }
 
 variable "docker_tag_explorer" {
@@ -132,8 +130,10 @@ variable "docker_tag_tor" {
 }
 
 variable "docker_tag_prometheus" {
-  type    = string
-  default = "blockstream/prometheus@sha256:a4803e2732f6b4b47f425ef9bceeb7942865a4d5ceef4d8e3ee9c7db8363a3d3"
+  type = string
+
+  # docker inspect --format='{{index .RepoDigests 0}}' prom/prometheus:v2.29.1
+  default = "prom/prometheus@sha256:ccc801f38fdac43f0ed3e1b0220777e976828d6558f8ef3baad9028e0d1797ae"
 }
 
 variable "min_ready_sec" {
@@ -152,10 +152,6 @@ variable "prometheus_allowed_source_ip" {
   type        = list(any)
   description = "The IPs that are allowed to access the prometheus instance."
   default     = []
-}
-
-variable "opsgenie_api_key" {
-  default = ""
 }
 
 variable "kms_location" {


### PR DESCRIPTION
updates the prometheus config, removing things we no longer need (assumes a Prometheus federation) and makes the setup more stable.