### PR TITLE
Update elements to 0.21.0

### DIFF
--- a/Dockerfile.deps
+++ b/Dockerfile.deps
@@ -33,12 +33,12 @@ RUN curl -sL -o bitcoin.tar.gz "https://bitcoincore.org/bin/bitcoin-core-${VERSI
  && ln -s "/srv/explorer/bitcoin-${VERSION_BITCOINCORE}" /srv/explorer/bitcoin \
  && rm bitcoin.tar.gz
 
-ENV SHA256SUM_ELEMENTS=b4038a34fcb3f1ed55acc0891cea8cd988ac8f164be2bb93d6dee24779744fae
-ENV VERSION_ELEMENTS=0.18.1.12
-RUN curl -sL -o elements.tar.gz "https://github.com/ElementsProject/elements/releases/download/elements-${VERSION_ELEMENTS}/elements-${VERSION_ELEMENTS}-x86_64-linux-gnu.tar.gz" \
+ENV SHA256SUM_ELEMENTS=37129b7227f107ba918a60d2901e6a0a2f5043ab353dd8fb2a8e55f8741a7991
+ENV VERSION_ELEMENTS=0.21.0
+RUN curl -sL -o elements.tar.gz "https://github.com/ElementsProject/elements/releases/download/elements-${VERSION_ELEMENTS}/elements-elements-${VERSION_ELEMENTS}-x86_64-linux-gnu.tar.gz" \
  && echo "${SHA256SUM_ELEMENTS}  elements.tar.gz" | sha256sum --check \
  && tar xzf elements.tar.gz -C /srv/explorer \
- && ln -s "/srv/explorer/elements-${VERSION_ELEMENTS}" /srv/explorer/liquid \
+ && ln -s "/srv/explorer/elements-elements-${VERSION_ELEMENTS}" /srv/explorer/liquid \
  && mv /srv/explorer/liquid/bin/{elementsd,liquidd} \
  && mv /srv/explorer/liquid/bin/{elements-cli,liquid-cli} \
  && rm elements.tar.gz

--- a/contrib/liquid-regtest-explorer.conf.in
+++ b/contrib/liquid-regtest-explorer.conf.in
@@ -2,6 +2,5 @@ chain=liquidregtest
 server=1
 validatepegin=0
 initialfreecoins=2100000000000000
-liquidregtest.rpcport=7041
 blocknotify=pkill -USR1 electrs
 fallbackfee=0.000001

--- a/run.sh
+++ b/run.sh
@@ -67,6 +67,9 @@ else
         NGINX_REWRITE='rewrite ^/liquidregtest(/.*)$ $1 break;'
         NGINX_REWRITE_NOJS='rewrite ^/liquidregtest(/.*)$ " /liquidregtest/nojs$1?" permanent'
         NGINX_NOSLASH_PATH="liquidregtest"
+
+	# The --jsonrpc-import works around electrs not yet being aware of the magic number change for liquid regtest in elements 21.
+        ELECTRS_ARGS="$ELECTRS_ARGS --jsonrpc-import"
     elif [ "${NETWORK}" == "testnet" ]; then
         ELECTRS_NETWORK="liquidtestnet"
         PARENT_NETWORK="--parent-network regtest"
@@ -265,6 +268,8 @@ if [ "${NETWORK}" == "regtest" ]; then
     else
         /srv/explorer/$DAEMON/bin/${DAEMON}d -conf=/data/.$DAEMON.conf -datadir=/data/$DAEMON -daemon
     fi
+    echo "Creating default wallet"
+    cli -rpcwait loadwallet default || cli createwallet default
     address=$(cli -rpcwait getnewaddress)
     cli generatetoaddress 100 ${address}
     cli stop


### PR DESCRIPTION
- pass --jsonrpc-import to electrs for liquid regtest to workaround magic number changing
- when in liquid/regtest mode, create a wallet (elements 21 does not load a wallet by default)