### PR TITLE
Update electrs to latest tip

### DIFF
--- a/Dockerfile.deps
+++ b/Dockerfile.deps
@@ -70,7 +70,7 @@ RUN source /root/.cargo/env \
  && mkdir -p /srv/explorer/electrs{,_liquid} \
  && git clone --no-checkout https://github.com/blockstream/electrs.git \
  && (cd electrs \
- && git checkout 703c6a20d52b61a234a18812503bd754d448992a \
+ && git checkout 253040e346664976c12e6c214ee2858a4dad2e06 \
  && cp contrib/popular-scripts.txt /srv/explorer \
  && cargo install --root /srv/explorer/electrs_bitcoin --locked --path . --features electrum-discovery \
  && cargo install --root /srv/explorer/electrs_liquid --locked --path . --features electrum-discovery,liquid) \

--- a/run.sh
+++ b/run.sh
@@ -78,7 +78,8 @@ else
         NGINX_REWRITE_NOJS='rewrite ^/liquidtestnet(/.*)$ " /liquidtestnet/nojs$1?" permanent'
         NGINX_NOSLASH_PATH="liquidtestnet"
 
-        ELECTRS_ARGS="$ELECTRS_ARGS --asset-db-path /srv/liquid-assets-db"
+        # The --jsonrpc-import works around electrs not yet being aware of the magic number change for liquid testnet
+        ELECTRS_ARGS="$ELECTRS_ARGS --jsonrpc-import --asset-db-path /srv/liquid-assets-db"
         ASSETS_GIT=${ASSETS_GIT:-https://github.com/Blockstream/asset_registry_testnet_db}
         ASSETS_GPG=${ASSETS_GPG:-/srv/explorer/source/contrib/asset_registry_testnet_pubkey.asc}
     else


### PR DESCRIPTION
- use jsonrpc-import for liquid-testnet to avoid chain binary incompatibilities