### PR TITLE
Remove a piece of documentation that is not true

### DIFF
--- a/API.md
+++ b/API.md
@@ -142,8 +142,6 @@ Available fields: `in_best_chain` (boolean, false for orphaned blocks), `next_be
 
 Returns a list of transactions in the block (up to 25 transactions beginning at `start_index`).
 
-Transactions returned here do not have the `status` field, since all the transactions share the same block and confirmation status.
-
 The response from this endpoint can be cached indefinitely.
 
 ### `GET /block/:hash/txids`


### PR DESCRIPTION
Actually, all transactions returned by the endpoint /block/:hash/txs[/:start_index] contains status information even if it's the same block.

[block 170 txs](https://blockstream.info/api/block/00000000d1145790a8694403d4063f323d499e655c83426834d4ce2f8dd4a2ee/txs)