### PR TITLE
Update: bitcoin core to v24 (w/ rebased savefeeestimate patch), elements to 22.0.2, rust to 1.65.0, enable transaction replacement

### DIFF
--- a/Dockerfile.deps
+++ b/Dockerfile.deps
@@ -65,7 +65,7 @@ RUN curl -sL -o elements.tar.gz "https://github.com/ElementsProject/elements/rel
  && mv /srv/explorer/liquid/bin/{elements-cli,liquid-cli} \
  && rm elements.tar.gz
 
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain 1.56.1
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain 1.65.0
 RUN source /root/.cargo/env \
  && mkdir -p /srv/explorer/electrs{,_liquid} \
  && git clone --no-checkout https://github.com/blockstream/electrs.git \

--- a/Dockerfile.deps
+++ b/Dockerfile.deps
@@ -32,9 +32,9 @@ RUN git clone --quiet --depth 1 --single-branch --branch v0.39.0 https://github.
 ENV CORE_PATCH=contrib/0001-add-support-to-save-fee-estimates-without-shutting-d.patch
 ENV CORE_SRC=/root/bitcoin
 COPY ${CORE_PATCH} /${CORE_PATCH}
-RUN git clone --quiet --depth 1 --branch v22.0 --single-branch --recursive https://github.com/bitcoin/bitcoin.git ${CORE_SRC} \
+RUN git clone --quiet --depth 1 --branch v24.0 --single-branch --recursive https://github.com/bitcoin/bitcoin.git ${CORE_SRC} \
  && (cd ${CORE_SRC} \
- && git checkout a0988140b71485ad12c3c3a4a9573f7c21b1eff8 \
+ && git checkout dd314fe0c2f64818d2789955a8ceef50d3d6597d \
  && git apply /${CORE_PATCH} \
  && (cd depends \
  && make HOST=x86_64-pc-linux-gnu NO_QT=1 -j $(nproc --all)) \

--- a/Dockerfile.deps
+++ b/Dockerfile.deps
@@ -55,12 +55,12 @@ RUN git clone --quiet --depth 1 --branch v24.0 --single-branch --recursive https
 # && ln -s "/srv/explorer/bitcoin-${VERSION_BITCOINCORE}" /srv/explorer/bitcoin \
 # && rm bitcoin.tar.gz
 
-ENV SHA256SUM_ELEMENTS=3018116794429b77ce0dd7436c2906f8be4eb5d6163b8451c5ce7e7bedad152b
-ENV VERSION_ELEMENTS=0.21.0.2
-RUN curl -sL -o elements.tar.gz "https://github.com/ElementsProject/elements/releases/download/elements-${VERSION_ELEMENTS}/elements-elements-${VERSION_ELEMENTS}-x86_64-linux-gnu.tar.gz" \
+ENV SHA256SUM_ELEMENTS=0278017429236f2cc651bb746e8ae826b740811d73789d07d1682649f2414465
+ENV VERSION_ELEMENTS=22.0.2
+RUN curl -sL -o elements.tar.gz "https://github.com/ElementsProject/elements/releases/download/elements-${VERSION_ELEMENTS}/elements-${VERSION_ELEMENTS}-x86_64-linux-gnu.tar.gz" \
  && echo "${SHA256SUM_ELEMENTS}  elements.tar.gz" | sha256sum --check \
  && tar xzf elements.tar.gz -C /srv/explorer \
- && ln -s "/srv/explorer/elements-elements-${VERSION_ELEMENTS}" /srv/explorer/liquid \
+ && ln -s "/srv/explorer/elements-${VERSION_ELEMENTS}" /srv/explorer/liquid \
  && mv /srv/explorer/liquid/bin/{elementsd,liquidd} \
  && mv /srv/explorer/liquid/bin/{elements-cli,liquid-cli} \
  && rm elements.tar.gz

--- a/contrib/0001-add-support-to-save-fee-estimates-without-shutting-d.patch
+++ b/contrib/0001-add-support-to-save-fee-estimates-without-shutting-d.patch
@@ -1,82 +1,82 @@
-From 3cf380db8f763f4522ef1bda21b3c5f200dced75 Mon Sep 17 00:00:00 2001
+From 9fc9638e54a3550f9842e0a5a8d5dce6551ed7ed Mon Sep 17 00:00:00 2001
 From: Lawrence Nahum <lawrence@greenaddress.it>
-Date: Fri, 29 Oct 2021 17:39:28 +0200
+Date: Sat, 19 Nov 2022 16:27:16 +0100
 Subject: [PATCH] add support to save fee estimates without shutting down the
  node
 
 ---
- src/policy/fees.cpp                           | 18 ++++---
+ src/policy/fees.cpp                           | 16 ++++--
  src/policy/fees.h                             |  3 ++
- src/rpc/misc.cpp                              | 27 ++++++++++
+ src/rpc/mempool.cpp                           | 29 ++++++++++
  src/test/fuzz/rpc.cpp                         |  1 +
  .../feature_fee_estimates_persist.py          | 54 +++++++++++++++++++
  test/functional/test_runner.py                |  1 +
- 6 files changed, 98 insertions(+), 6 deletions(-)
+ 6 files changed, 99 insertions(+), 5 deletions(-)
  create mode 100755 test/functional/feature_fee_estimates_persist.py
 
 diff --git a/src/policy/fees.cpp b/src/policy/fees.cpp
-index 2ae5798eb..8a5ac99fb 100644
+index 2b940be07..7edd5807f 100644
 --- a/src/policy/fees.cpp
 +++ b/src/policy/fees.cpp
-@@ -883,12 +883,7 @@ CFeeRate CBlockPolicyEstimator::estimateSmartFee(int confTarget, FeeCalculation
+@@ -903,11 +903,7 @@ CFeeRate CBlockPolicyEstimator::estimateSmartFee(int confTarget, FeeCalculation
  
  void CBlockPolicyEstimator::Flush() {
      FlushUnconfirmed();
 -
--    fs::path est_filepath = gArgs.GetDataDirNet() / FEE_ESTIMATES_FILENAME;
--    CAutoFile est_file(fsbridge::fopen(est_filepath, "wb"), SER_DISK, CLIENT_VERSION);
+-    AutoFile est_file{fsbridge::fopen(m_estimation_filepath, "wb")};
 -    if (est_file.IsNull() || !Write(est_file)) {
--        LogPrintf("Failed to write fee estimates to %s. Continue anyway.\n", est_filepath.string());
+-        LogPrintf("Failed to write fee estimates to %s. Continue anyway.\n", fs::PathToString(m_estimation_filepath));
 -    }
 +    Write();
  }
  
- bool CBlockPolicyEstimator::Write(CAutoFile& fileout) const
-@@ -916,6 +911,17 @@ bool CBlockPolicyEstimator::Write(CAutoFile& fileout) const
+ bool CBlockPolicyEstimator::Write(AutoFile& fileout) const
+@@ -935,6 +931,16 @@ bool CBlockPolicyEstimator::Write(AutoFile& fileout) const
      return true;
  }
  
 +bool CBlockPolicyEstimator::Write() const
 +{
-+    fs::path est_filepath = gArgs.GetDataDirNet() / FEE_ESTIMATES_FILENAME;
-+    CAutoFile est_file(fsbridge::fopen(est_filepath, "wb"), SER_DISK, CLIENT_VERSION);
++    AutoFile est_file{fsbridge::fopen(m_estimation_filepath, "wb")};
 +    if (est_file.IsNull() || !Write(est_file)) {
-+        LogPrintf("Failed to write fee estimates to %s. Continue anyway.\n", est_filepath.string());
++        LogPrintf("Failed to write fee estimates to %s. Continue anyway.\n", fs::PathToString(m_estimation_filepath));
 +        return false;
 +    }
 +    return true;
 +}
 +
- bool CBlockPolicyEstimator::Read(CAutoFile& filein)
+ bool CBlockPolicyEstimator::Read(AutoFile& filein)
  {
      try {
 diff --git a/src/policy/fees.h b/src/policy/fees.h
-index c444d71a3..9d178d0a6 100644
+index e4628bf85..f4ac5c00e 100644
 --- a/src/policy/fees.h
 +++ b/src/policy/fees.h
-@@ -213,6 +213,9 @@ public:
-     /** Write estimation data to a file */
-     bool Write(CAutoFile& fileout) const;
+@@ -223,6 +223,9 @@ public:
+     bool Write(AutoFile& fileout) const
+         EXCLUSIVE_LOCKS_REQUIRED(!m_cs_fee_estimator);
  
 +    /** Write estimation data to the default file */
-+    bool Write() const;
++    bool Write() const EXCLUSIVE_LOCKS_REQUIRED(!m_cs_fee_estimator);
 +
      /** Read estimation data from a file */
-     bool Read(CAutoFile& filein);
+     bool Read(AutoFile& filein)
+         EXCLUSIVE_LOCKS_REQUIRED(!m_cs_fee_estimator);
+diff --git a/src/rpc/mempool.cpp b/src/rpc/mempool.cpp
+index 5c1770704..20083a974 100644
+--- a/src/rpc/mempool.cpp
++++ b/src/rpc/mempool.cpp
+@@ -22,6 +22,9 @@
+ #include <util/moneystr.h>
+ #include <util/time.h>
  
-diff --git a/src/rpc/misc.cpp b/src/rpc/misc.cpp
-index 5178ce60e..0050b82a6 100644
---- a/src/rpc/misc.cpp
-+++ b/src/rpc/misc.cpp
-@@ -14,6 +14,7 @@
- #include <key_io.h>
- #include <node/context.h>
- #include <outputtype.h>
 +#include <policy/fees.h>
- #include <rpc/blockchain.h>
- #include <rpc/server.h>
- #include <rpc/util.h>
-@@ -328,6 +329,31 @@ static RPCHelpMan verifymessage()
++
++
+ using kernel::DumpMempool;
+ 
+ using node::DEFAULT_MAX_RAW_TX_FEE_RATE;
+@@ -705,6 +708,31 @@ static RPCHelpMan getmempoolinfo()
      };
  }
  
@@ -105,22 +105,22 @@ index 5178ce60e..0050b82a6 100644
 +    };
 +}
 +
- static RPCHelpMan signmessagewithprivkey()
+ static RPCHelpMan savemempool()
  {
-     return RPCHelpMan{"signmessagewithprivkey",
-@@ -759,6 +785,7 @@ static const CRPCCommand commands[] =
-     { "util",               &deriveaddresses,         },
-     { "util",               &getdescriptorinfo,       },
-     { "util",               &verifymessage,           },
-+    { "util",               &savefeeestimates,        },
-     { "util",               &signmessagewithprivkey,  },
-     { "util",               &getindexinfo,            },
- 
+     return RPCHelpMan{"savemempool",
+@@ -898,6 +926,7 @@ void RegisterMempoolRPCCommands(CRPCTable& t)
+         {"blockchain", &getmempoolinfo},
+         {"blockchain", &getrawmempool},
+         {"blockchain", &savemempool},
++        {"blockchain", &savefeeestimates},
+         {"hidden", &submitpackage},
+     };
+     for (const auto& c : commands) {
 diff --git a/src/test/fuzz/rpc.cpp b/src/test/fuzz/rpc.cpp
-index 9195cc487..df41004fa 100644
+index 26913a41d..977ae63a9 100644
 --- a/src/test/fuzz/rpc.cpp
 +++ b/src/test/fuzz/rpc.cpp
-@@ -76,6 +76,7 @@ const std::vector<std::string> RPC_COMMANDS_NOT_SAFE_FOR_FUZZING{
+@@ -80,6 +80,7 @@ const std::vector<std::string> RPC_COMMANDS_NOT_SAFE_FOR_FUZZING{
      "importwallet", // avoid reading from disk
      "loadwallet",   // avoid reading from disk
      "prioritisetransaction", // avoid signed integer overflow in CTxMemPool::PrioritiseTransaction(uint256 const&, long const&) (https://github.com/bitcoin/bitcoin/issues/20626)
@@ -189,10 +189,10 @@ index 000000000..c6d82345b
 +if __name__ == "__main__":
 +    FeeEstimatesPersistTest().main()
 diff --git a/test/functional/test_runner.py b/test/functional/test_runner.py
-index 725706947..a2f50b537 100755
+index d78c1c634..bf9dbe12a 100755
 --- a/test/functional/test_runner.py
 +++ b/test/functional/test_runner.py
-@@ -134,6 +134,7 @@ BASE_SCRIPTS = [
+@@ -136,6 +136,7 @@ BASE_SCRIPTS = [
      # vv Tests less than 30s vv
      'wallet_keypool_topup.py --legacy-wallet',
      'wallet_keypool_topup.py --descriptors',
@@ -201,5 +201,5 @@ index 725706947..a2f50b537 100755
      'interface_zmq.py',
      'rpc_invalid_address_message.py',
 -- 
-2.20.1
+2.30.2
 

--- a/contrib/bitcoin-mainnet-explorer.conf.in
+++ b/contrib/bitcoin-mainnet-explorer.conf.in
@@ -4,5 +4,5 @@ peerbloomfilters=0
 enforcenodebloom=1
 disablewallet=1
 listenonion=1
-listen=0
+listen=1
 blocknotify=pkill -USR1 electrs

--- a/contrib/bitcoin-mainnet-explorer.conf.in
+++ b/contrib/bitcoin-mainnet-explorer.conf.in
@@ -5,4 +5,5 @@ enforcenodebloom=1
 disablewallet=1
 listenonion=1
 listen=1
+mempoolfullrbf=1
 blocknotify=pkill -USR1 electrs

--- a/contrib/bitcoin-regtest-explorer.conf.in
+++ b/contrib/bitcoin-regtest-explorer.conf.in
@@ -1,6 +1,6 @@
 regtest=1
 [regtest]
 server=1
-listen=0
+listen=1
 blocknotify=pkill -USR1 electrs
 fallbackfee=0.00001

--- a/contrib/bitcoin-regtest-explorer.conf.in
+++ b/contrib/bitcoin-regtest-explorer.conf.in
@@ -2,5 +2,6 @@ regtest=1
 [regtest]
 server=1
 listen=1
+mempoolfullrbf=1
 blocknotify=pkill -USR1 electrs
 fallbackfee=0.00001

--- a/contrib/bitcoin-signet-explorer.conf.in
+++ b/contrib/bitcoin-signet-explorer.conf.in
@@ -5,5 +5,5 @@ peerbloomfilters=0
 enforcenodebloom=1
 disablewallet=1
 listenonion=1
-listen=0
+listen=1
 blocknotify=pkill -USR1 electrs

--- a/contrib/bitcoin-signet-explorer.conf.in
+++ b/contrib/bitcoin-signet-explorer.conf.in
@@ -6,4 +6,5 @@ enforcenodebloom=1
 disablewallet=1
 listenonion=1
 listen=1
+mempoolfullrbf=1
 blocknotify=pkill -USR1 electrs

--- a/contrib/bitcoin-testnet-explorer.conf.in
+++ b/contrib/bitcoin-testnet-explorer.conf.in
@@ -5,5 +5,5 @@ peerbloomfilters=0
 enforcenodebloom=1
 disablewallet=1
 listenonion=1
-listen=0
+listen=1
 blocknotify=pkill -USR1 electrs

--- a/contrib/bitcoin-testnet-explorer.conf.in
+++ b/contrib/bitcoin-testnet-explorer.conf.in
@@ -6,4 +6,5 @@ enforcenodebloom=1
 disablewallet=1
 listenonion=1
 listen=1
+mempoolfullrbf=1
 blocknotify=pkill -USR1 electrs


### PR DESCRIPTION
Updates:

- bitcoin core to v24 (w/ rebased savefeeestimate patch)
- elements to 22.0.2
- rust to 1.65.0
- enable transaction replacement