### PR TITLE
bitcoind configs: set maxmempool to 1000 MB

### DIFF
--- a/contrib/bitcoin-mainnet-explorer.conf.in
+++ b/contrib/bitcoin-mainnet-explorer.conf.in
@@ -7,3 +7,4 @@ listenonion=1
 listen=1
 mempoolfullrbf=1
 blocknotify=pkill -USR1 electrs
+maxmempool=1000

--- a/contrib/bitcoin-regtest-explorer.conf.in
+++ b/contrib/bitcoin-regtest-explorer.conf.in
@@ -5,3 +5,4 @@ listen=1
 mempoolfullrbf=1
 blocknotify=pkill -USR1 electrs
 fallbackfee=0.00001
+maxmempool=1000

--- a/contrib/bitcoin-signet-explorer.conf.in
+++ b/contrib/bitcoin-signet-explorer.conf.in
@@ -8,3 +8,4 @@ listenonion=1
 listen=1
 mempoolfullrbf=1
 blocknotify=pkill -USR1 electrs
+maxmempool=1000

--- a/contrib/bitcoin-testnet-explorer.conf.in
+++ b/contrib/bitcoin-testnet-explorer.conf.in
@@ -8,3 +8,4 @@ listenonion=1
 listen=1
 mempoolfullrbf=1
 blocknotify=pkill -USR1 electrs
+maxmempool=1000


### PR DESCRIPTION
Updates the bitcoind config templates to set `maxmempool` to 1000 MB