### PR TITLE
Disable Elements unblinding in the server-side rendering environment

### DIFF
--- a/client/src/app.js
+++ b/client/src/app.js
@@ -58,7 +58,7 @@ export default function main({ DOM, HTTP, route, storage, scanner: scan$, search
     , sort_dir: loc.query.sort_dir != null ? loc.query.sort_dir : 'asc'
     , limit: +loc.query.limit || 50,
     }))
-  , blindingReq$ = !process.env.IS_ELEMENTS ? O.empty()
+  , blindingReq$ = !(process.env.IS_ELEMENTS && process.browser) ? O.empty()
       : page$.map(loc => loc.hash.startsWith('#blinded=') ? loc.hash.substr(9) : null)
   // End Elements only
 


### PR DESCRIPTION
Attempting to access the URL hash fragment (`location.hash`) on the server-side was causing an error, because it is not available there.

Unblinding should only be done on the client-side for privacy reasons anyway, so this feature can be disabled entirely on the server-side.