### PR TITLE
fix docker service stop

### DIFF
--- a/contrib/runit_boot.sh
+++ b/contrib/runit_boot.sh
@@ -9,6 +9,9 @@ shutdown() {
   # next shut down electrs (avoid long wait + losing blocks in bitcoind)
   sv -w "$SVWAIT" force-stop electrs
 
+  # next shut down bitcoin (longer timeout to allow for a clean shutdown)
+  sv -w "$BCWAIT" force-stop bitcoin
+
   # then shutdown any other service started by runit
   for _srv in $(ls -1 /etc/service); do
     sv -w "$SVWAIT" force-stop "$_srv"
@@ -33,6 +36,7 @@ export > /etc/envvars
 
 PATH=/usr/local/bin:/usr/local/sbin:/bin:/sbin:/usr/bin:/usr/sbin:/usr/X11R6/bin
 SVWAIT=60  # wait process to end up to SVWAIT seconds before sending kill signal
+BCWAIT=300 # custom timeout for bitcoind before sending kill signal
 
 # run all scripts in the run_once folder
 /bin/run-parts /etc/run_once


### PR DESCRIPTION
This PR changes the order in which services are stopped when the docker container is shut down.

With the previous order (based on `ls` output) I was getting the following logs:
```
shutting down container
4-2024-02-01T22:07:20Z tor: Thread interrupt
4-2024-02-01T22:07:20Z Shutdown: In progress...
4-2024-02-01T22:07:20Z RemoveLocal(g4xk3jxhqac4qqexdrnhk2mnd4c6dnmufvt4mifkwiyipvq7xzj5i3qd.onion:18444)
4-2024-02-01T22:07:20Z opencon thread exit
4-2024-02-01T22:07:20Z torcontrol thread exit
4-2024-02-01T22:07:20Z addcon thread exit
4-2024-02-01T22:07:20Z net thread exit
4-2024-02-01T22:07:20Z msghand thread exit
2-2024-02-01T22:07:20.430+00:00 - WARN - reconnecting to bitcoind: failed to read cookie from "/data/bitcoin/regtest/.cookie"
2-2024-02-01T22:07:23.431+00:00 - WARN - failed to connect daemon at 127.0.0.1:18443: Connection refused (os error 111)
2-2024-02-01T22:07:26.431+00:00 - WARN - failed to connect daemon at 127.0.0.1:18443: Connection refused (os error 111)
kill: run: bitcoin: (pid 75) 35s, want down, got TERM
2-2024-02-01T22:07:27.660+00:00 - TRACE - stop accepting new RPCs
2-2024-02-01T22:07:27.660+00:00 - TRACE - closing 0 RPC connections
2-2024-02-01T22:07:27.660+00:00 - TRACE - RPC connections are closed
2-2024-02-01T22:07:27.660+00:00 - TRACE - RPC server is stopped
2-2024-02-01T22:07:27.660+00:00 - ERROR - server failed: Error: Iterrupted by signal 15
2-   0: <unknown>
2-   1: <unknown>
2-   2: <unknown>
2-   3: <unknown>
2-   4: <unknown>
2-   5: <unknown>
2-   6: <unknown>
2-   7: <unknown>
2-   8: <unknown>
2-   9: <unknown>
2-  10: __libc_start_main
2-  11: <unknown>
2-
2-
2-2024-02-01T22:07:27.662+00:00 - TRACE - deregistering event source from poller
ok: down: electrs: 1s, normally up
ok: down: nginx: 0s, normally up
ok: down: prerenderer: 0s, normally up
ok: down: socat: 1s, normally up
ok: down: tor: 0s, normally up
```
Also, when starting the container again, bitcoind was always resuming from height 0, instead of the one it was at before the stop was requested.

With the change in this PR I am getting:
```
shutting down container
ok: down: nginx: 0s, normally up
6-Feb 01 22:11:19.000 [notice] Catching signal TERM, exiting cleanly.
4-2024-02-01T22:11:19Z RemoveLocal(3z4bdbvidw6aq46z7gxkj6nrvfukatdw4bvlyh2lakz5ranswsga3jad.onion:18444)
ok: down: tor: 1s, normally up
ok: down: socat: 0s, normally up
ok: down: websocket: 0s, normally up
ok: down: prerenderer: 1s, normally up
ok: down: electrs: 0s, normally up
ok: down: bitcoin: 1s, normally up
```
Also, when starting the container again, bitcoind resumes from the height it was before the stop was requested.

Notes:
- tested using `bitcoin-regtest`
- I also took the liberty to address some (shellcheck) lint warnings