### PR TITLE
updated to catch missing 404 for not found routes

### DIFF
--- a/client/src/run-server.js
+++ b/client/src/run-server.js
@@ -31,7 +31,7 @@ export default function render(pathname, args='', body, locals={}, cb) {
     cb(null, data || {
       html: lastHtml
     , title: lastState.title
-    , status: lastState.view == 'notFound' ? 404 : lastState.error ? 400 : 200
+    , status: (lastState.view == 'notFound' || lastHtml.includes("Not Found")) ? 404 : lastState.error ? 400 : 200
     })
   }
 


### PR DESCRIPTION
cycles doesn't expose the raw request, and I've yet to find the actual place that builds the response that is parsed in the render callback. 