### PR TITLE
prerender: Wait for the loading state to complete, fix HTTP error status codes

### DIFF
--- a/client/src/run-server.js
+++ b/client/src/run-server.js
@@ -31,7 +31,9 @@ export default function render(pathname, args='', body, locals={}, cb) {
     cb(null, data || {
       html: lastHtml
     , title: lastState.title
-    , status: lastState.view == 'notFound' ? 404 : lastState.error ? 400 : 200
+    , status: lastState.view == 'notFound' ? 404
+            : lastState.view == 'error' ? lastState.error.status || 400
+            : 200
     })
   }
 

--- a/client/src/run-server.js
+++ b/client/src/run-server.js
@@ -46,7 +46,7 @@ export default function render(pathname, args='', body, locals={}, cb) {
 
     lastState = S
 
-    if (S.loading || !S.isReady) {
+    if (S.view == 'loading' || S.loading > 0) {
       if (!seenLoading) {
         seenLoading = true
         clearTimeout(timeout)

--- a/client/src/util.js
+++ b/client/src/util.js
@@ -112,7 +112,7 @@ export const dropErrors = r$$ => r$$.switchMap(r$ => r$.catch(_ => O.empty()))
 
 export const extractErrors = r$$ =>
   r$$.flatMap(r$ => r$.flatMap(_ => O.empty()).catch(err => O.of(err)))
-    .map(e => e.response && e.status != 502 ? parseError(e.response) : e)
+    .map(e => e.response ? responseError(e.response) : e)
 
 // Create a stream that ticks every `ms`, but only when the window is focused.
 // Returns an empty stream in the server-side pre-renderer environment.
@@ -126,10 +126,12 @@ export const tickWhileFocused = ms =>
 export const tickWhileViewing = (ms, view, view$) =>
   tickWhileFocused(ms).withLatestFrom(view$).filter(([ _, shown_view ]) => shown_view == view)
 
-const parseError = res =>
-  (res.body && Object.keys(res.body).length)
-  ? res.body.message || res.body
-  : res.text
+const responseError = res => ({
+  status: res.status,
+  message: (res.body && Object.keys(res.body).length)
+    ? res.body.message || res.body
+    : res.text
+})
 
 export const dbg = (obj, label='stream', dbg=debug(label)) =>
   Object.keys(obj).forEach(k => obj[k] && obj[k].subscribe(

--- a/client/src/views/error.js
+++ b/client/src/views/error.js
@@ -6,7 +6,7 @@ const formatError = err =>
 ? 'We encountered an error. Please try again later.'
 : (err.status && err.status === 502)
 ? 'Esplora is currently unavailable, please try again later.'
-: err.toString()
+: (err.message || err.toString())
 
 export const error = ({ t, error, ...S }) => layout(<div>
     <div className="container text-center"><h1>{ t(formatError(error)) }</h1></div>


### PR DESCRIPTION
Prior to this fix, `render()` preemptively considered the app rendering to be final, before completing the transition out of the loading state entirely.

This resulted in notFound pages not being identified as such, returning them with a 200 OK status code instead of a 404 Not Found.