### PR TITLE
liquid: add discount_vsize and discount_weight to tx display

### DIFF
--- a/client/src/views/tx.js
+++ b/client/src/views/tx.js
@@ -161,6 +161,14 @@ const txHeader = (tx, { tipHeight, mempool, feeEst, t
       <div>{t`Weight units`}</div>
       <div>{`${formatNumber(tx.weight)} WU`}</div>
     </div>
+    { tx.discount_vsize != null && <div>
+      <div>{t`Discount virtual size`}</div>
+      <div>{`${formatNumber(tx.discount_vsize)} vB`}</div>
+    </div> }
+    { tx.discount_weight != null && <div>
+      <div>{t`Discount weight units`}</div>
+      <div>{`${formatNumber(tx.discount_weight)} WU`}</div>
+    </div> }
     <div>
       <div>{t`Version`}</div>
       <div>{tx.version}</div>


### PR DESCRIPTION
Add UI display for Liquid discount_vsize and discount_weight fields.

Not visible in non liquid chains.

In liquid:

![image](https://github.com/user-attachments/assets/6bb4326d-d80e-450f-91c6-26eb9e8fb0ed)
