### PR TITLE
reduce right margin for subnav links

### DIFF
--- a/www/style.css
+++ b/www/style.css
@@ -2919,6 +2919,14 @@ h3.table-title{
   }
 }
 
+@media only screen and (max-width: 1280px) {
+
+  .sub-nav a{
+    margin-right: 30px;
+  }
+
+}
+
 @media only screen and (max-width: 475px) {
 
   .sub-nav {
@@ -2943,10 +2951,6 @@ h3.table-title{
 
   .sub-nav{
     flex-wrap: wrap;
-  }
-
-  .sub-nav a{
-    margin-right: 20px;
   }
 }
 


### PR DESCRIPTION
<img width="912" alt="Screenshot 2025-02-13 at 5 03 55 PM" src="https://github.com/user-attachments/assets/62bf08a8-bcae-4935-bc2c-910d3fe7a48b" />

Prevent word breaking across lines