### PR TITLE
docker: Update libwally-core to latest

### DIFF
--- a/Dockerfile.deps
+++ b/Dockerfile.deps
@@ -5,10 +5,10 @@ ARG NO_LIQUID
 ENV EXPORTED_FUNCTIONS="['_malloc', '_free', '_wally_init','_wally_asset_value_commitment','_wally_asset_generator_from_bytes']"
 ENV EXTRA_EXPORTED_RUNTIME_METHODS="['getValue', 'ccall']"
 ENV EMCC_OPTIONS="-s MODULARIZE=1 -s EXPORT_NAME=InitWally"
-RUN sh -c '[ -n "$NO_LIQUID" ] && mkdir -p /wally/wally_dist || ( \
+RUN sh -c '[ -n "$NO_LIQUID" ] && mkdir -p /wally/dist || ( \
     cd /opt/emsdk && . ./emsdk_env.sh \
     && git clone --no-checkout https://github.com/elementsproject/libwally-core /wally \
-    && cd /wally && git checkout ea984fc07f4f450b33d4eb78756f25f553e60b44 \
+    && cd /wally && git checkout f394af85081cbebea50f470373a89f77ad52cb94 \
     && git submodule sync --recursive && git submodule update --init --recursive \
     && ./tools/build_wasm.sh --enable-elements)'
 
@@ -89,4 +89,4 @@ RUN apt-get --auto-remove remove -yqq --purge ${ESPLORA_BUILD_DEPS} manpages ${C
  && apt-get autoclean \
  && rm -rf /usr/share/doc* /usr/share/man /usr/share/postgresql/*/man /var/lib/apt/lists/* /var/cache/* /tmp/* /root/.cache /*.deb /root/.cargo
 
-COPY --from=libwally-wasm /wally/wally_dist /srv/wally_wasm
+COPY --from=libwally-wasm /wally/dist /srv/wally_wasm


### PR DESCRIPTION
We can now use the latest libwally-core, following https://github.com/ElementsProject/libwally-core/pull/491 which allows to override `EMCC_OPTIONS` entirely.

The build target directory was also changed from `wally_dist` to just `dist`, in https://github.com/ElementsProject/libwally-core/commit/f4229b58c7d21e699c60983f7edb44266651a4e0#diff-099d172147ace15dd52979d57196e96d3c9dc8fa77f92fb9e216e1301600c35fL46-R46.