### PR TITLE
check for and display simplicity transaction inputs

### DIFF
--- a/client/src/lib/elements.js
+++ b/client/src/lib/elements.js
@@ -1,0 +1,79 @@
+import {formatAssetAmount} from "../views/util";
+
+export const getSupply = (asset, t) => {
+    let { chain_stats = {}, mempool_stats = {} } = asset
+    let has_blinded_issuances =
+        chain_stats.has_blinded_issuances || mempool_stats.has_blinded_issuances
+    let is_native_asset = !asset.issuance_txin
+    let circulating = is_native_asset
+        ? chain_stats.peg_in_amount +
+        mempool_stats.peg_in_amount -
+        chain_stats.peg_out_amount -
+        mempool_stats.peg_out_amount -
+        chain_stats.burned_amount -
+        mempool_stats.burned_amount
+        : has_blinded_issuances
+            ? null
+            : chain_stats.issued_amount +
+            mempool_stats.issued_amount -
+            chain_stats.burned_amount -
+            mempool_stats.burned_amount;
+
+    let totalSupply = circulating == null ? t`Confidential`
+        : formatAssetAmount(circulating, asset.precision, t)
+    return totalSupply
+}
+
+
+// Simplicity helpers (Elements only)
+
+// Helper to check if witness has an annex (per BIP 341)
+const hasAnnex = (witness) => witness && witness.length >= 2 && witness[witness.length - 1].startsWith('50')
+
+// Get the control block element from a witness stack (accounting for optional annex)
+const getControlBlock = witness => {
+    if (!witness || witness.length < 3) return null
+    const hasAnnexBlock = hasAnnex(witness)
+    if (hasAnnexBlock) {
+        return witness[witness.length - 2]
+    }
+    return witness[witness.length - 1]
+}
+
+export const isSimplicityTapleafVersion = (controlBlock) => {
+    return controlBlock && (controlBlock.startsWith('be') || controlBlock.startsWith('bf'))
+}
+
+// Check if a vin is a P2TR Simplicity spend
+// A P2TR Simplicity spend has:
+// - 4 witness elements (or 5 with optional annex)
+// - is a simplicity Tapleaf
+export const isSimplicitySpend = (vin) => {
+    if (!process.env.IS_ELEMENTS || !vin.witness) return false
+
+    const witnessLen = vin.witness.length
+    const hasAnnexBlock = hasAnnex(vin.witness)
+
+    // Must be 4 elements without annex, or 5 elements with annex
+    if (witnessLen !== 4 && !(witnessLen === 5 && hasAnnexBlock)) return false
+
+    const controlBlock = getControlBlock(vin.witness)
+    return isSimplicityTapleafVersion(controlBlock)
+}
+
+// Extract Simplicity witness components from a vin
+// Returns: { witnessData, program, cmr, controlBlock, annex }
+export const getSimplicityWitness = (vin) => {
+    if (!isSimplicitySpend(vin)) return null
+
+    const witness = vin.witness
+    const hasAnnexBlock = hasAnnex(witness)
+
+    return {
+        witnessData: witness[0],
+        program: witness[1],
+        cmr: witness[2],
+        controlBlock: witness[3],
+        annex: hasAnnexBlock && witness.length === 5 ? witness[4] : null
+    }
+}

--- a/client/src/views/asset-list.js
+++ b/client/src/views/asset-list.js
@@ -1,5 +1,5 @@
 import Snabbdom from 'snabbdom-pragma'
-import { getSupply } from './util'
+import { getSupply } from '../lib/elements.js'
 import layout from './layout'
 import loader from '../components/loading'
 

--- a/client/src/views/tx-vin.js
+++ b/client/src/views/tx-vin.js
@@ -1,5 +1,6 @@
 import Snabbdom from 'snabbdom-pragma'
-import { linkToParentOut, formatOutAmount, formatAssetAmount, formatHex, linkToAddr, formatNumber } from './util'
+import { linkToParentOut, formatOutAmount, formatAssetAmount, formatHex, linkToAddr, formatNumber, hexToBase64 } from './util'
+import { isSimplicitySpend, getSimplicityWitness } from '../lib/elements.js'
 
 const layout = (vin, desc, body, { t, ...S }) =>
   <div class={{ vin: true, active: isActive(vin, S), unblinded: isUnblinded(vin) }}>
@@ -103,10 +104,37 @@ const standard = (vin, { isOpen, t, ...S }, assetMeta=getAssetMeta(vin, S)) => l
       </div>
     ] }
 
-    { vin.witness && <div className="vin-body-row">
+    { vin.witness && !isSimplicitySpend(vin) && <div className="vin-body-row">
       <div>{t`Witness`}</div>
       <div className="mono">{vin.witness.map(wit => [ ' ', wit.length ? wit : <em>&lt;empty&gt;</em> ])}</div>
     </div> }
+
+    { isSimplicitySpend(vin) && ((sw = getSimplicityWitness(vin)) => [
+      <div className="vin-body-row">
+        <div>{t`Simplicity witness data`}</div>
+        <div className="mono">{sw.witnessData}</div>
+      </div>
+
+    , <div className="vin-body-row">
+            <div>{t`Simplicity program`} <br></br> {t`(base64)`}</div>
+        <div className="mono">{hexToBase64(sw.program)}</div>
+      </div>
+
+    , <div className="vin-body-row">
+        <div>{t`Simplicity CMR`}</div>
+        <div className="mono">{sw.cmr}</div>
+      </div>
+
+    , <div className="vin-body-row">
+        <div>{t`Taproot control block`}</div>
+        <div className="mono">{sw.controlBlock}</div>
+      </div>
+
+    , sw.annex && <div className="vin-body-row">
+        <div>{t`Taproot Annex`}</div>
+        <div className="mono">{sw.annex}</div>
+      </div>
+    ])() }
 
     { vin.inner_redeemscript_asm && <div className="vin-body-row">
       <div>{t`P2SH redeem script`}</div>

--- a/client/src/views/util.js
+++ b/client/src/views/util.js
@@ -97,28 +97,10 @@ export const formatVMB = bytes =>
 : '< 0.01 vMB'
 
 
-export const getSupply = (asset, t) => {
-  let { chain_stats = {}, mempool_stats = {} } = asset
-  let has_blinded_issuances =
-      chain_stats.has_blinded_issuances || mempool_stats.has_blinded_issuances
-  let is_native_asset = !asset.issuance_txin
-  let circulating = is_native_asset
-      ? chain_stats.peg_in_amount +
-        mempool_stats.peg_in_amount -
-        chain_stats.peg_out_amount -
-        mempool_stats.peg_out_amount -
-        chain_stats.burned_amount -
-        mempool_stats.burned_amount
-      : has_blinded_issuances
-      ? null
-      : chain_stats.issued_amount +
-        mempool_stats.issued_amount -
-        chain_stats.burned_amount -
-        mempool_stats.burned_amount;
-
-     let totalSupply = circulating == null ? t`Confidential`
-                  : formatAssetAmount(circulating, asset.precision, t)
-  return totalSupply
-}
-
 export const strTruncate  = (str) => str.substr(0, 10) + '...' + str.substr(str.length-4, str.length);
+
+
+// Convert hex string to base64
+export const hexToBase64 = (hex) => {
+    return Buffer.from(hex, 'hex').toString('base64')
+}


### PR DESCRIPTION
- on liquid chains, provide additional information when a transaction input is a simplicity program
- display program in base64 (not hex)