### PR TITLE
Change the year on footer to be dynamic

### DIFF
--- a/flavors/blockstream/config.env
+++ b/flavors/blockstream/config.env
@@ -1,5 +1,5 @@
 export SITE_DESC='Blockstream Explorer is an open source block explorer providing detailed blockchain data across Bitcoin, Testnet, and Liquid. Supports Tor and tracking-free.'
-export SITE_FOOTER='© 2025 Blockstream Corporation Inc. All rights reserved.'
+export SITE_FOOTER="© $(date +%Y) Blockstream Corporation Inc. All rights reserved."
 export HEAD_HTML=\
 '<meta property="og:image" content="https://blockstream.info/img/social-sharing.png">'\
 '<meta name="twitter:image" content="https://blockstream.info/img/social-sharing.png">'\


### PR DESCRIPTION
## Fix: Dynamic Footer Year

### Problem
The footer currently displays a hardcoded year: `© 2025 Blockstream Corporation Inc. All rights reserved` (see screenshot below).

<img width="1850" height="1007" alt="hardcoded-year" src="https://github.com/user-attachments/assets/ab4bf02b-d9c9-4246-ad69-5ca267b2975b" />


This means the year has to be manually updated every year in `flavors/blockstream/config.env`.

### Solution
I replaced the hardcoded year with a dynamic value that automatically updates on every page load.

<img width="1858" height="1053" alt="dynamic-year-value" src="https://github.com/user-attachments/assets/16c9ea7b-8c2c-4fc7-b0e2-2e6eda018157" />
