### PR TITLE
Fix status code for prerendered pages

### DIFF
--- a/prerender-server/src/server.js
+++ b/prerender-server/src/server.js
@@ -139,7 +139,7 @@ function doRender(req, res, next) {
       return res.sendStatus(resp.errorCode)
     }
 
-    res.status(resp.status || 200)
+    res.status(200)
     res.render(indexView, {
       prerender_title: resp.title
       , prerender_html: resp.html


### PR DESCRIPTION
The prerender server now always returns `200 OK` when page HTML is successfully rendered.

- If `resp.redirect` exists, the server returns 301 via `res.redirect(301, ...)`
- If `resp.errorCode` exists, the server returns that code via `res.sendStatus(resp.errorCode)]`, for example 500, 504).
- If `err` is thrown, it is passed to error handling `next(err)`, typically resulting in 5xx.

Rendered pages always return 200, so API-side 4xx/5xx no longer leak into the final HTTP status if content was rendered.