### PR TITLE
Added optional chaining to fix search bug on chrome.

### DIFF
--- a/client/src/driver/instascan.js
+++ b/client/src/driver/instascan.js
@@ -15,7 +15,7 @@ if (navigator.mediaDevices && navigator.mediaDevices.getUserMedia) {
     document.body.appendChild(script)
   }
 
-  const Instascan$ = O.fromEvent(document.body, 'load', true).filter(e => e.target.src.endsWith('/instascan.min.js')).map(_ => window.Instascan).share()
+  const Instascan$ = O.fromEvent(document.body, 'load', true).filter(e => e.target.src?.endsWith('/instascan.min.js')).map(_ => window.Instascan).share()
       , Scanner$   = Instascan$.map(Instascan => Instascan.Scanner)
       , Camera$    = Instascan$.map(Instascan => Instascan.Camera)
 


### PR DESCRIPTION
Since SVGs trigger load events in Chrome, the SVG added in #617 is now being processed by the Instascan observable. The observable assumes that every element emitting a load event has a src property, but SVG elements do not, which causes a UI error.

This behavior appears to be browser-dependent, so the issue is not reproducible in Firefox.