### PR TITLE
Add optional BASE_PREFIX to serve the site under a sub-directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ All options are optional.
 
 - `NODE_ENV` - set to `production` to enable js minification, or to `development` to disable (defaults to `production`)
 - `BASE_HREF` - base href for user interface (defaults to `/`, change if not served from the root directory)
+- `BASE_PREFIX` - optional path prefix prepended to each flavor's `BASE_HREF`, to serve the whole multi-network site under a sub-directory (e.g. `BASE_PREFIX=preview` serves `/preview/`, `/preview/signet/`, ...). `API_URL` is left un-prefixed so a prefixed build still uses the same backend
 - `STATIC_ROOT` - root for static assets (defaults to `BASE_HREF`, change to load static assets from a different server)
 - `API_URL` - URL for HTTP REST API (defaults to `/api`, change if the API is available elsewhere)
 - `CANONICAL_URL` - absolute base url for user interface (optional, only required for opensearch and canonical link tags)

--- a/build.sh
+++ b/build.sh
@@ -9,6 +9,16 @@ export NODE_ENV=${NODE_ENV:=production}
 export BASE_HREF=${BASE_HREF:-/}
 export API_URL=${API_URL:-"${BASE_HREF}api"}
 
+# Optional path prefix for serving the whole site under a sub-directory (e.g. a preview
+# deploy keyed by branch name). Applied *after* the flavor sets its per-network BASE_HREF,
+# so the network paths are preserved: / -> /$BASE_PREFIX/, /signet/ -> /$BASE_PREFIX/signet/.
+# API_URL is resolved above, before this, so it keeps pointing at the un-prefixed network
+# API and a prefixed build still talks to the same backend.
+if [ -n "$BASE_PREFIX" ]; then
+  export BASE_HREF="/${BASE_PREFIX#/}${BASE_HREF}"
+  export BASE_PREFIX="/${BASE_PREFIX#/}"
+fi
+
 mkdir -p $DEST
 rm -rf $DEST/*
 

--- a/client/src/views/nav-toggle.js
+++ b/client/src/views/nav-toggle.js
@@ -1,6 +1,9 @@
 import { nativeAssetId } from '../const'
 
 const staticRoot = process.env.STATIC_ROOT || ''
+// Prefix for cross-network links so they stay within the current deployment root when the
+// whole site is served under a sub-directory (BASE_PREFIX). Empty for a root deployment.
+const siteRoot = process.env.BASE_PREFIX || ''
 const hasCam = process.browser && navigator.mediaDevices && navigator.mediaDevices.getUserMedia
 
 export default () =>
@@ -40,10 +43,10 @@ export default () =>
         <div className="link-list">
           <h4 className="menu-title font-h5">Explorers</h4>
           <ul className="font-p3">
-            <li><a href="/" rel="external">Bitcoin</a></li>
-            <li><a href="/liquid/" rel="external">Liquid Network</a></li>
-            <li><a href="/testnet/" rel="external" target="_blank">Bitcoin Testnet</a></li>
-            <li><a href="/liquidtestnet/" rel="external" target="_blank">Liquid Testnet</a></li>
+            <li><a href={`${siteRoot}/`} rel="external">Bitcoin</a></li>
+            <li><a href={`${siteRoot}/liquid/`} rel="external">Liquid Network</a></li>
+            <li><a href={`${siteRoot}/testnet/`} rel="external" target="_blank">Bitcoin Testnet</a></li>
+            <li><a href={`${siteRoot}/liquidtestnet/`} rel="external" target="_blank">Liquid Testnet</a></li>
           </ul>
           <h4 className="menu-title font-h5">Developer Tools</h4>
           <ul className="font-p3">

--- a/client/src/views/navbar.js
+++ b/client/src/views/navbar.js
@@ -1,8 +1,6 @@
 import menu from './navbar-menu'
 
 const staticRoot = process.env.STATIC_ROOT || ''
-// Deployment root prefix, set when the site is served under a sub-directory (BASE_PREFIX).
-const siteRoot = process.env.BASE_PREFIX || ''
 
 export default S =>
 
@@ -15,7 +13,7 @@ export default S =>
             <a href="blocks/recent" class={{ active: S.activeTab == 'recentBlocks' }}>Blocks</a>
             <a href="tx/recent" class={{ active: S.activeTab == 'recentTxs' }}>Transactions</a>
             { process.env.IS_ELEMENTS ? <a href="assets" class={{ active: S.activeTab == 'assets' }}>Assets<sup className="highlight"></sup></a> : "" }
-            <a href={`${siteRoot}/explorer-api`} class={{ active: S.activeTab == 'apiLanding' }}>Explorer API</a>
+            <a href="explorer-api" class={{ active: S.activeTab == 'apiLanding' }}>Explorer API</a>
         </div>
       { menu(S) }
   </nav>

--- a/client/src/views/navbar.js
+++ b/client/src/views/navbar.js
@@ -1,6 +1,8 @@
 import menu from './navbar-menu'
 
 const staticRoot = process.env.STATIC_ROOT || ''
+// Deployment root prefix, set when the site is served under a sub-directory (BASE_PREFIX).
+const siteRoot = process.env.BASE_PREFIX || ''
 
 export default S =>
 
@@ -13,7 +15,7 @@ export default S =>
             <a href="blocks/recent" class={{ active: S.activeTab == 'recentBlocks' }}>Blocks</a>
             <a href="tx/recent" class={{ active: S.activeTab == 'recentTxs' }}>Transactions</a>
             { process.env.IS_ELEMENTS ? <a href="assets" class={{ active: S.activeTab == 'assets' }}>Assets<sup className="highlight"></sup></a> : "" }
-            <a href="/explorer-api" class={{ active: S.activeTab == 'apiLanding' }}>Explorer API</a>
+            <a href={`${siteRoot}/explorer-api`} class={{ active: S.activeTab == 'apiLanding' }}>Explorer API</a>
         </div>
       { menu(S) }
   </nav>

--- a/client/src/views/network-selection.js
+++ b/client/src/views/network-selection.js
@@ -2,6 +2,10 @@ const items = process.env.MENU_ITEMS && JSON.parse(process.env.MENU_ITEMS),
   active = process.env.MENU_ACTIVE;
 
 const staticRoot = process.env.STATIC_ROOT || "";
+// Keep cross-network links within the current deployment root when the site is served under a
+// sub-directory (BASE_PREFIX). No-op for a root deployment (empty prefix).
+const siteRoot = process.env.BASE_PREFIX || "";
+const withRoot = (url) => (siteRoot && url && url.charAt(0) === "/" ? siteRoot + url : url);
 const itemEntries = items ? Object.entries(items) : [];
 const activeName = active || (itemEntries[0] && itemEntries[0][0]);
 const activeId = activeName && activeName.replace(/ /g, "");
@@ -43,7 +47,7 @@ export default ({ t, page }) => (
                   return (
                     <a
                       id={name.replace(/ /g, "")}
-                      href={url}
+                      href={withRoot(url)}
                       className={`network-hover-menu-option-container ${name.replace(/ /g, "").toLowerCase()} ${name === activeName ? "active" : ""}`}
                       rel="external"
                     >


### PR DESCRIPTION
## What

Adds an optional `BASE_PREFIX` build option so the whole multi-network site can be served from a sub-directory instead of the domain root.

Setting `BASE_PREFIX=preview` produces a build served at:

- `/preview/` (bitcoin mainnet)
- `/preview/signet/`, `/preview/testnet/`, ...
- `/preview/liquid/`, `/preview/liquidtestnet/`, ...

This is useful for hosting more than one build of the explorer side by side under a single host (e.g. a long-lived branch/preview build alongside the main one).

## How it works

- `build.sh` applies `BASE_PREFIX` **after** each flavor's `config.env` resolves its per-network `BASE_HREF`, so the network sub-paths are preserved (`/signet/` → `/preview/signet/`).
- `API_URL` is resolved **before** the prefix is applied and is left un-prefixed, so a prefixed build keeps talking to the same API backend rather than expecting a prefixed API.
- The few cross-network links that are absolute (the network switcher in `network-selection.js` / `nav-toggle.js`, and the Explorer API tab in `navbar.js`) are routed through the prefix so they stay within the current deployment root instead of jumping back to `/`.

## Compatibility

`BASE_PREFIX` is optional and defaults to empty. With no prefix set the build output and all links are unchanged.

## Notes

`prerender-server` is not covered by this change.