### PR TITLE
Fixed unblinded output formatting.

### DIFF
--- a/client/src/components/status-badge.js
+++ b/client/src/components/status-badge.js
@@ -3,7 +3,9 @@ export const StatusBadge = (
   children,
 ) => (
   <span
-    className={["status-badge", variant, className].filter(Boolean).join(" ")}
+    class={["status-badge", variant, className]
+      .filter(Boolean)
+      .reduce((classes, name) => ({ ...classes, [name]: true }), {})}
   >
     {children}
   </span>

--- a/client/src/views/util.js
+++ b/client/src/views/util.js
@@ -48,7 +48,13 @@ export const formatOutAmount = (vout, { t, assetMap }, shortDisplay=false) => {
   const amount_el = formatAssetAmount(vout.value, precision, t)
       , asset_link = vout.asset && <a href={asset_url}>{short_id}</a>
 
-  return domain ? <span>{amount_el} {ticker && <span title={name}>{ticker}</span>} {shortDisplay||<br />} {domain}{shortDisplay || [<br/>,<em title={vout.asset}>{asset_link}</em>]}</span>
+  return domain ? shortDisplay
+       ? <span>{amount_el} {ticker && <span title={name}>{ticker}</span>} {domain}</span>
+       : <span class={{ 'asset-amount-details': true }}>
+           <span>{amount_el} {ticker && <span title={name}>{ticker}</span>}</span>
+           <span>{domain}</span>
+           <em title={vout.asset}>{asset_link}</em>
+         </span>
        : vout.asset ? <span>{amount_el} <em title={vout.asset}>{asset_link}</em></span>
        : <span>{amount_el} {t`Unknown`}</span> // should never happen
 }

--- a/www/style.css
+++ b/www/style.css
@@ -1906,6 +1906,12 @@ body::after{
   justify-content: right;
 }
 
+.asset-amount-details {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+}
+
 .unblinded .vout-header, .unblinded .vin-header {
   background: #04240d;
 }
@@ -2083,6 +2089,10 @@ body::after{
     text-align: left !important;
     margin: 0 !important;
     padding: 3px 0;
+  }
+
+  .asset-amount-details {
+    align-items: flex-start;
   }
 
   .vin-header-container {


### PR DESCRIPTION
To run locally, npm install and use the following snippets:
```
# Liquid
export API_URL=https://blockstream.info/liquid/api
export PORT=5000
source flavors/blockstream/config.env
source flavors/liquid-mainnet/config.env
npm run dev-server
```
---
To test:
- Download wallycore.js and wallycore.wasm located at `https://blockstream.info/liquid/libwally/wallycore.js` and `https://blockstream.info/liquid/libwally/wallycore.wasm` respectively
- Make a folder called `libwally` in `client/src/lib/` and place the 2 downloaded files in there
- Add the following lines to dev-server.js after the line `router.get('/app.js', browserify(rpath('client/src/run-browser.js')))`:
```
router.get('/libwally/wallycore.js', (req, res) => res.sendFile(rpath('client/src/lib/libwally/wallycore.js')))
router.get('/libwally/wallycore.wasm', (req, res) => res.sendFile(rpath('client/src/lib/libwally/wallycore.wasm')))
```
- Now download `assets.minimal.json` from `https://blockstream.info/liquid/_data/assets.minimal.json` and put it in `www/_data` (making the directory if it's not there)
- Visit `http://localhost:5000/liquid/tx/e6d8feb9a539628fe9386570fc6c546315a1ce37d64ce104fc742545c45102ea#blinded=100,f266a3f15e78b71481adfedff9aefe47c69501a181ffc68527bb5fb26da6a4b2,3d48822703130651d51583438f5d4692b337b9483a1b4d81d158672a4f288838,7dadf08a4b5750f4795a48f7ede24732ea6efca3dc46c51806d332fdd6464cc3` and verify the output is unblinded with the formatting presented in the screenshot below
---
<img width="1728" height="1117" alt="Screenshot 2026-08-03 at 3 08 28 PM" src="https://github.com/user-attachments/assets/46762e74-7ade-4628-8a31-1441aa458029" />
