### PR TITLE
Added fee market components.

### DIFF
--- a/client/src/const.js
+++ b/client/src/const.js
@@ -4,10 +4,20 @@ export const blocksPerPage = 10
 export const difficultyPeriod = 2016
 export const maxMempoolTxs = 50
 export const satoshisPerBitcoin = 100000000
-export const averageNativeSegwitTransactionSize = 140
+export const typicalNativeSegwitTransactionVsize = 140
+// One native-SegWit input, two confidential outputs, and an explicit fee
+// output. After ELIP-200 normalizes confidential values, nonces, and proofs,
+// its discount weight is 228 base-equivalent bytes * 4 plus 117 witness bytes
+// (using a 108-byte P2WPKH witness), rounded up from 1029 WU.
+export const typicalDiscountedConfidentialTransactionVsize = 258
 export const maxBlockWeight = 4000000
 export const blockGridLoadingDelayMs = 100
 export const blockGridTransactionSelectEvent = 'block-grid-transaction-select'
+export const feeEstimateTargets = {
+  low: 12,
+  average: 3,
+  high: 1,
+}
 
 const configuredTargetBlockIntervalSeconds = Number(process.env.TARGET_BLOCK_INTERVAL_SECONDS)
 export const targetBlockIntervalSeconds = configuredTargetBlockIntervalSeconds > 0

--- a/client/src/lib/block-template.js
+++ b/client/src/lib/block-template.js
@@ -1,4 +1,4 @@
-import { maxBlockWeight } from "../const";
+import { feeEstimateTargets, maxBlockWeight } from "../const";
 import { feeRateClass } from "./fees";
 import { clamp } from "./math";
 
@@ -47,7 +47,11 @@ const summarizeFeeBucket = (transactions) => {
 };
 
 const summarizeFeeBuckets = (transactions, feeEst) => {
-  if (!feeEst || feeEst[3] == null || feeEst[12] == null) {
+  if (
+    !feeEst ||
+    feeEst[feeEstimateTargets.average] == null ||
+    feeEst[feeEstimateTargets.low] == null
+  ) {
     return { low: null, medium: null, high: null };
   }
 

--- a/client/src/lib/fees.js
+++ b/client/src/lib/fees.js
@@ -1,11 +1,22 @@
+import {
+  feeEstimateTargets,
+  satoshisPerBitcoin,
+  typicalDiscountedConfidentialTransactionVsize,
+  typicalNativeSegwitTransactionVsize,
+} from '../const'
+
 const MAX_BLOCK_VSIZE = 1000000
+    , typicalTransactionVsize = process.env.IS_ELEMENTS
+        ? typicalDiscountedConfidentialTransactionVsize
+        : typicalNativeSegwitTransactionVsize
 
 export const getFeeTierBoundaries = feeEst => {
-  const low = feeEst && feeEst[12]
-    , high = feeEst && feeEst[3]
+  const lowMaximum = feeEst && feeEst[feeEstimateTargets.low]
+    , mediumMaximum = feeEst && feeEst[feeEstimateTargets.average]
 
-  return Number.isFinite(low) && Number.isFinite(high) && low >= 0 && high >= 0
-    ? { low, high: Math.max(low, high) }
+  return Number.isFinite(lowMaximum) && Number.isFinite(mediumMaximum)
+      && lowMaximum >= 0 && mediumMaximum >= 0
+    ? { lowMaximum, mediumMaximum: Math.max(lowMaximum, mediumMaximum) }
     : null
 }
 
@@ -13,9 +24,9 @@ export const feeRateClass = (feerate, feeEst) => {
   const boundaries = getFeeTierBoundaries(feeEst)
   if (!Number.isFinite(feerate) || !boundaries) return ""
 
-  return feerate <= boundaries.low
+  return feerate <= boundaries.lowMaximum
     ? "success"
-    : feerate <= boundaries.high
+    : feerate <= boundaries.mediumMaximum
       ? "warning"
       : "danger"
 }
@@ -36,6 +47,17 @@ export function getConfEstimate(fee_estimates, feerate) {
     .sort((a, b) => a[0]-b[0])
     .find(([ target, target_feerate ]) => target_feerate <= feerate)
   return target_est ? target_est[0] : -1
+}
+
+// Estimate the USD cost of a typical transaction at a given fee-rate. Elements
+// uses the ELIP-200 discount virtual size rather than serialized virtual size.
+export function estimateTypicalTransactionFeeUsd(bitcoinPrice, feerate) {
+  return Number.isFinite(bitcoinPrice) && bitcoinPrice >= 0
+      && Number.isFinite(feerate) && feerate >= 0
+    ? (bitcoinPrice / satoshisPerBitcoin) *
+        feerate *
+        typicalTransactionVsize
+    : null
 }
 
 // Squash the fee histogram into fixed feerate ranges

--- a/client/src/lib/market.js
+++ b/client/src/lib/market.js
@@ -1,0 +1,9 @@
+export const getBitcoinPrices = marketChart =>
+  (Array.isArray(marketChart?.prices) ? marketChart.prices : [])
+    .map(price => Array.isArray(price) ? price[1] : null)
+    .filter(Number.isFinite)
+
+export const getLatestBitcoinPrice = marketChart => {
+  const prices = getBitcoinPrices(marketChart)
+  return prices.length ? prices[prices.length - 1] : null
+}

--- a/client/src/lib/pending-block-details.js
+++ b/client/src/lib/pending-block-details.js
@@ -47,9 +47,6 @@ const formatTrimmedDecimal = (value) =>
 export const formatPanelPercentage = (value, fallback = "N/A") =>
   Number.isFinite(value) ? `${formatTrimmedDecimal(value)}%` : fallback;
 
-export const formatFeeRate = (value, fallback = "N/A") =>
-  Number.isFinite(value) ? `${value.toFixed(2)} sat/vB` : fallback;
-
 export const formatFeeBoundary = (value, fallback = "N/A") =>
   Number.isFinite(value) ? value.toFixed(2) : fallback;
 
@@ -65,22 +62,6 @@ export const formatMegabytes = (value, fallback = "N/A") =>
 
 export const formatCount = (value, fallback = "N/A") =>
   Number.isFinite(value) ? value.toLocaleString() : fallback;
-
-export const getLatestBitcoinPrice = (marketChart) => {
-  const prices = ((marketChart && marketChart.prices) || [])
-    .map((price) => price && price[1])
-    .filter(Number.isFinite);
-
-  return prices.length ? prices[prices.length - 1] : null;
-};
-
-export const formatUsd = (value, fallback = "N/A") =>
-  Number.isFinite(value)
-    ? `$${value.toLocaleString("en-US", {
-        minimumFractionDigits: 2,
-        maximumFractionDigits: 2,
-      })} USD`
-    : fallback;
 
 export const formatTransactionDelta = (delta) =>
   delta > 0

--- a/client/src/views/fee-market.js
+++ b/client/src/views/fee-market.js
@@ -1,0 +1,53 @@
+import { InfoCard } from "../components/info-card";
+import { feeEstimateTargets } from "../const";
+import { estimateTypicalTransactionFeeUsd } from "../lib/fees";
+import { getLatestBitcoinPrice } from "../lib/market";
+import { formatFeeRate, formatUsd } from "./util";
+
+const getFeeMarketLevels = (t) => [
+  {
+    key: "low",
+    title: t`Low`,
+    tooltip: t`A lower-priority fee rate estimated to confirm within ${feeEstimateTargets.low} blocks.`,
+  },
+  {
+    key: "average",
+    title: t`Average`,
+    tooltip: t`A balanced fee rate estimated to confirm within ${feeEstimateTargets.average} blocks.`,
+  },
+  {
+    key: "high",
+    title: t`High`,
+    tooltip: t`A higher-priority fee rate estimated to confirm in the next block.`,
+  },
+];
+
+export const feeMarket = ({ feeEst, bitcoinMarketChart, t } = {}) => {
+  const bitcoinPrice = getLatestBitcoinPrice(bitcoinMarketChart);
+  const unavailable = t`N/A`;
+
+  return (
+    <div className="fee-market">
+      <p className="section-title">{t`Fee Market`}</p>
+      <div className="fee-market-body">
+        {getFeeMarketLevels(t).map(({ key, title, tooltip }) => {
+          const feerate = feeEst && feeEst[feeEstimateTargets[key]];
+          const feeUsd = estimateTypicalTransactionFeeUsd(
+            bitcoinPrice,
+            feerate,
+          );
+
+          return (
+            <InfoCard
+              className={`fee-market-${key}`}
+              title={title}
+              tooltip={tooltip}
+              value={formatFeeRate(feerate, unavailable)}
+              footer={formatUsd(feeUsd, unavailable)}
+            />
+          );
+        })}
+      </div>
+    </div>
+  );
+};

--- a/client/src/views/home.js
+++ b/client/src/views/home.js
@@ -3,6 +3,7 @@ import { blks } from "./blocks";
 import { transactions } from "./transactions";
 import { pegInfo } from "./peg-info";
 import { overview } from "./overview";
+import { feeMarket } from "./fee-market";
 import difficultyAdjustment from "./difficulty-adjustment";
 import { isBitcoinNetwork } from "../lib/network";
 import { showPegData } from "../const";
@@ -19,12 +20,14 @@ export const dashBoard = ({ t, blocks, dashboardState, loading, ...S }) => {
     <div className="home-page" key="dashBoard">
       {overview({ blocks: dashblocks, t, ...S })}
       {blks(dashblocks, true, { t, ...S })}
+      {isBitcoinNetwork ? feeMarket({ t, ...S }) : ""}
       <div className="dashboard-transaction-section">
         {transactions(dashTxs, true, { t, ...S })}
         {showPegData
           ? pegInfo(peg.asset, peg.txs, { t, ...S, error: peg.error })
           : ""}
       </div>
+      {!isBitcoinNetwork ? feeMarket({ t, ...S }) : ""}
       {isBitcoinNetwork
         ? difficultyAdjustment({ blocks: dashblocks, ...S })
         : ""}

--- a/client/src/views/overview.js
+++ b/client/src/views/overview.js
@@ -1,46 +1,19 @@
-import {
-  averageNativeSegwitTransactionSize,
-  satoshisPerBitcoin,
-} from "../const";
+import { feeEstimateTargets } from "../const";
 import { ElapsedTime } from "../components/elapsed-time";
 import { InfoCard } from "../components/info-card";
 import { MempoolCongestion } from "../components/mempool-congestion";
 import { ReferenceLineChart } from "../components/reference-line-chart";
+import { estimateTypicalTransactionFeeUsd } from "../lib/fees";
+import {
+  getBitcoinPrices,
+  getLatestBitcoinPrice,
+} from "../lib/market";
+import { formatFeeRate, formatUsd } from "./util";
 
 const staticRoot = process.env.STATIC_ROOT || "";
 
-const getBitcoinPrices = (marketChart) =>
-  ((marketChart && marketChart.prices) || [])
-    .map((price) => price && price[1])
-    .filter(Number.isFinite);
-
 const getChartPrices = (marketChart) =>
   getBitcoinPrices(marketChart).slice(-24);
-
-const formatUsd = (value) =>
-  Number.isFinite(value)
-    ? `$${value.toLocaleString("en-US", {
-        minimumFractionDigits: 2,
-        maximumFractionDigits: 2,
-      })} USD`
-    : "";
-
-const formatRecommendedFee = (feeEst) =>
-  feeEst && Number.isFinite(feeEst[3]) ? `${feeEst[3].toFixed(1)} sat/vB` : "";
-
-const estimateNativeSegwitFeeUsd = (bitcoinPrice, feeEst) =>
-  Number.isFinite(bitcoinPrice) && feeEst && Number.isFinite(feeEst[3])
-    ? formatUsd(
-        (bitcoinPrice / satoshisPerBitcoin) *
-          feeEst[3] *
-          averageNativeSegwitTransactionSize,
-      )
-    : "";
-
-const getLatestPrice = (marketChart) => {
-  const prices = getBitcoinPrices(marketChart);
-  return prices.length ? prices[prices.length - 1] : null;
-};
 
 export const overview = ({
   blocks,
@@ -51,10 +24,12 @@ export const overview = ({
 } = {}) => {
   const latestBlock = blocks && blocks[0];
   const chartPrices = getChartPrices(bitcoinMarketChart);
-  const currentBitcoinPrice = getLatestPrice(bitcoinMarketChart);
-  const recommendedFeeUsd = estimateNativeSegwitFeeUsd(
+  const currentBitcoinPrice = getLatestBitcoinPrice(bitcoinMarketChart);
+  const recommendedFeerate =
+    feeEst && feeEst[feeEstimateTargets.average];
+  const recommendedFeeUsd = estimateTypicalTransactionFeeUsd(
     currentBitcoinPrice,
-    feeEst,
+    recommendedFeerate,
   );
   return (
     <div className="overview">
@@ -78,8 +53,8 @@ export const overview = ({
         <InfoCard
           title={t`Recommended Fee`}
           tooltip={t`Suggested rate (sat/vB) to confirm in the next block or two.`}
-          value={formatRecommendedFee(feeEst)}
-          footer={recommendedFeeUsd}
+          value={formatFeeRate(recommendedFeerate, t`N/A`)}
+          footer={formatUsd(recommendedFeeUsd, t`N/A`)}
         />
 
         <InfoCard
@@ -96,7 +71,7 @@ export const overview = ({
         <InfoCard
           title={t`Bitcoin`}
           iconSrc={`${staticRoot}img/icons/Bitcoin-menu-logo.svg`}
-          headerValue={formatUsd(currentBitcoinPrice)}
+          headerValue={formatUsd(currentBitcoinPrice, t`N/A`)}
           body={
             <ReferenceLineChart
               className="overview-bitcoin-price-chart"

--- a/client/src/views/pending-block-details-card.js
+++ b/client/src/views/pending-block-details-card.js
@@ -19,16 +19,14 @@ import { getFeeTierBoundaries } from "../lib/fees";
 import {
   formatCount,
   formatFeeBoundary,
-  formatFeeRate,
   formatMegabytes,
   formatPanelPercentage,
   formatPercentage,
   formatTransactionDelta,
-  formatUsd,
   formatWeight,
-  getLatestBitcoinPrice,
 } from "../lib/pending-block-details";
-import { formatSat, formatVMB } from "./util";
+import { getLatestBitcoinPrice } from "../lib/market";
+import { formatFeeRate, formatSat, formatUsd, formatVMB } from "./util";
 
 // Fee estimates are inclusive upper bounds, while the grid expects inclusive
 // lower thresholds. Move just beyond a boundary so an equal rate stays in the
@@ -55,14 +53,14 @@ const getBlockGridConfig = (
           color: rgbColor("--success-color-rgb"),
         },
         medium: {
-          threshold: exclusiveFeeTierMinimum(boundaries.low),
+          threshold: exclusiveFeeTierMinimum(boundaries.lowMaximum),
           color: rgbColor("--warning-color-rgb"),
         },
         high: {
           threshold: exclusiveFeeTierMinimum(
             Math.max(
-              boundaries.high,
-              exclusiveFeeTierMinimum(boundaries.low),
+              boundaries.mediumMaximum,
+              exclusiveFeeTierMinimum(boundaries.lowMaximum),
             ),
           ),
           color: rgbColor("--danger-color-rgb"),
@@ -516,7 +514,7 @@ const PendingBlockDetailsCard = ({
                   <div className="pending-block-color-reference success"></div>
                   <p className="pending-block-legend-label">
                     {t`Low`} (
-                    {`≤${formatFeeBoundary(feeTierBoundaries.low)} sat/vB`}
+                    {`≤${formatFeeBoundary(feeTierBoundaries.lowMaximum)} sat/vB`}
                     )
                   </p>
                 </div>
@@ -524,7 +522,7 @@ const PendingBlockDetailsCard = ({
                   <div className="pending-block-color-reference warning"></div>
                   <p className="pending-block-legend-label">
                     {t`Medium`} (
-                    {`>${formatFeeBoundary(feeTierBoundaries.low)}–≤${formatFeeBoundary(feeTierBoundaries.high)} sat/vB`}
+                    {`>${formatFeeBoundary(feeTierBoundaries.lowMaximum)}–≤${formatFeeBoundary(feeTierBoundaries.mediumMaximum)} sat/vB`}
                     )
                   </p>
                 </div>
@@ -532,7 +530,7 @@ const PendingBlockDetailsCard = ({
                   <div className="pending-block-color-reference danger"></div>
                   <p className="pending-block-legend-label">
                     {t`High`} (
-                    {`>${formatFeeBoundary(feeTierBoundaries.high)} sat/vB`}
+                    {`>${formatFeeBoundary(feeTierBoundaries.mediumMaximum)} sat/vB`}
                     )
                   </p>
                 </div>

--- a/client/src/views/util.js
+++ b/client/src/views/util.js
@@ -24,6 +24,20 @@ export const formatTime = (unix, with_tz = true) => {
 
 export const formatSat = (sats, label=nativeAssetLabel) => `${formatNumber(sat2btc(sats), NATIVE_PRECISION)} ${label}`
 
+const formatTrimmedDecimal = value =>
+  value.toFixed(2).replace(/\.?0+$/, '')
+
+export const formatFeeRate = (feerate, fallback='N/A') =>
+  Number.isFinite(feerate) ? `${formatTrimmedDecimal(feerate)} sat/vB` : fallback
+
+export const formatUsd = (value, fallback='N/A') =>
+  Number.isFinite(value)
+    ? `$${value.toLocaleString('en-US', {
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+      })} USD`
+    : fallback
+
 export const formatAssetAmount = (value, precision=0, t) =>
   <span>
     {formatNumber(precision > 0 ? moveDec(value, -precision) : value, precision)}

--- a/lang/strings.txt
+++ b/lang/strings.txt
@@ -1,3 +1,6 @@
+A balanced fee rate estimated to confirm within %s blocks.
+A higher-priority fee rate estimated to confirm in the next block.
+A lower-priority fee rate estimated to confirm within %s blocks.
 Address
 Address reuse
 Address: %s
@@ -10,6 +13,7 @@ Asset ID
 Asset name
 Asset: %s
 Assets vs Liabilities
+Average
 Bits
 BLOCK
 Block Challenge
@@ -55,9 +59,11 @@ Esplora is currently unavailable, please try again later.
 ETA
 Estimated time until the peg transaction is confirmed.
 Fee
+Fee Market
 Federation BTC Holdings
 Go
 Height
+High
 How full the block is.
 In block
 In best chain
@@ -81,6 +87,7 @@ Linked domain
 Loading block...
 Loading...
 Load more
+Low
 Lock time
 ltr
 Mempool

--- a/test/fee-market.test.js
+++ b/test/fee-market.test.js
@@ -1,0 +1,75 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const render = require("snabbdom-to-html");
+
+const { feeMarket } = require("../client/src/views/fee-market");
+
+const t = (parts, ...values) => parts.reduce(
+  (result, part, index) =>
+    result + part + (index < values.length ? values[index] : ""),
+  "",
+);
+
+test("renders low, average, and high fee estimates with dollar footers", () => {
+  const html = render(feeMarket({
+    feeEst: {
+      1: 12,
+      3: 6,
+      12: 2,
+    },
+    bitcoinMarketChart: {
+      prices: [[1, 40_000], [2, 50_000], [3, null]],
+    },
+    t,
+  }));
+
+  const expectedUsd = process.env.IS_ELEMENTS
+    ? ["$0.26 USD", "$0.77 USD", "$1.55 USD"]
+    : ["$0.14 USD", "$0.42 USD", "$0.84 USD"];
+
+  assert.match(html, /Low[\s\S]*2 sat\/vB/);
+  assert.match(html, /Average[\s\S]*6 sat\/vB/);
+  assert.match(html, /High[\s\S]*12 sat\/vB/);
+  expectedUsd.forEach((value) => assert(html.includes(value), value));
+  assert.match(html, /within 12 blocks/);
+  assert.match(html, /within 3 blocks/);
+  assert.match(html, /in the next block/);
+  assert.doesNotMatch(html, /\[object Object\]/);
+});
+
+test("keeps fee market panels visible while estimates are unavailable", () => {
+  const html = render(feeMarket({ t }));
+
+  assert.match(html, /Fee Market/);
+  assert.match(html, /Low/);
+  assert.match(html, /Average/);
+  assert.match(html, /High/);
+  assert.match(html, /N\/A/);
+  assert.doesNotMatch(html, /sat\/vB/);
+  assert.doesNotMatch(html, /USD/);
+});
+
+test("passes fee market copy through localization", () => {
+  const localizedStrings = new Set();
+  const localizedT = (parts, ...values) => {
+    localizedStrings.add(parts.join("%s"));
+    return parts.reduce(
+      (result, part, index) =>
+        result + part + (index < values.length ? values[index] : ""),
+      "",
+    );
+  };
+
+  render(feeMarket({ t: localizedT }));
+
+  [
+    "A balanced fee rate estimated to confirm within %s blocks.",
+    "A higher-priority fee rate estimated to confirm in the next block.",
+    "A lower-priority fee rate estimated to confirm within %s blocks.",
+    "Average",
+    "Fee Market",
+    "High",
+    "Low",
+    "N/A",
+  ].forEach((value) => assert(localizedStrings.has(value), value));
+});

--- a/test/fees.test.js
+++ b/test/fees.test.js
@@ -3,6 +3,7 @@ const assert = require("node:assert/strict");
 
 const {
   feeRateClass,
+  estimateTypicalTransactionFeeUsd,
   feerateCutoff,
   getConfEstimate,
   getFeeTierBoundaries,
@@ -10,12 +11,12 @@ const {
 
 test("validates and applies fee tier boundaries", () => {
   assert.deepEqual(getFeeTierBoundaries({ 3: 10, 12: 2 }), {
-    low: 2,
-    high: 10,
+    lowMaximum: 2,
+    mediumMaximum: 10,
   });
   assert.deepEqual(getFeeTierBoundaries({ 3: 1, 12: 2 }), {
-    low: 2,
-    high: 2,
+    lowMaximum: 2,
+    mediumMaximum: 2,
   });
   assert.equal(getFeeTierBoundaries(), null);
   assert.equal(getFeeTierBoundaries({ 3: 10, 12: -1 }), null);
@@ -54,4 +55,15 @@ test("selects a confirmation target by numeric order", () => {
 
   assert.equal(getConfEstimate(estimates, 6), "10");
   assert.equal(getConfEstimate(estimates, 0.5), -1);
+});
+
+test("estimates a typical transaction fee in dollars", () => {
+  const expectedFee = process.env.IS_ELEMENTS ? 1.548 : 0.84;
+
+  assert.equal(estimateTypicalTransactionFeeUsd(50_000, 12), expectedFee);
+  assert.equal(estimateTypicalTransactionFeeUsd(50_000, 0), 0);
+  assert.equal(estimateTypicalTransactionFeeUsd(null, 12), null);
+  assert.equal(estimateTypicalTransactionFeeUsd(50_000, undefined), null);
+  assert.equal(estimateTypicalTransactionFeeUsd(-50_000, 12), null);
+  assert.equal(estimateTypicalTransactionFeeUsd(50_000, -12), null);
 });

--- a/test/format-number.test.js
+++ b/test/format-number.test.js
@@ -1,7 +1,11 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
 
-const { formatNumber } = require("../client/src/views/util");
+const {
+  formatFeeRate,
+  formatNumber,
+  formatUsd,
+} = require("../client/src/views/util");
 
 test("separates whole-number digits into groups of three", () => {
   assert.equal(formatNumber(999), "999");
@@ -16,4 +20,18 @@ test("preserves exact decimal strings and requested precision", () => {
     "12,345,678,901,234,567,890.12345678",
   );
   assert.equal(formatNumber("1234.5", 3), "1,234.500");
+});
+
+test("formats fee rates with up to two decimal places and a fallback", () => {
+  assert.equal(formatFeeRate(2), "2 sat/vB");
+  assert.equal(formatFeeRate(2.5), "2.5 sat/vB");
+  assert.equal(formatFeeRate(2.555), "2.56 sat/vB");
+  assert.equal(formatFeeRate(null), "N/A");
+  assert.equal(formatFeeRate(undefined, "-"), "-");
+});
+
+test("formats dollar values with a fallback", () => {
+  assert.equal(formatUsd(1_234.5), "$1,234.50 USD");
+  assert.equal(formatUsd(null), "N/A");
+  assert.equal(formatUsd(undefined, "-"), "-");
 });

--- a/test/market.test.js
+++ b/test/market.test.js
@@ -1,0 +1,20 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  getBitcoinPrices,
+  getLatestBitcoinPrice,
+} = require("../client/src/lib/market");
+
+test("selects finite market prices and the latest available value", () => {
+  const marketChart = {
+    prices: [[1, 100], null, [2, NaN], [3, 125]],
+  };
+
+  assert.deepEqual(getBitcoinPrices(marketChart), [100, 125]);
+  assert.equal(getLatestBitcoinPrice(marketChart), 125);
+  assert.deepEqual(getBitcoinPrices(null), []);
+  assert.equal(getLatestBitcoinPrice(null), null);
+  assert.deepEqual(getBitcoinPrices({ prices: {} }), []);
+  assert.deepEqual(getBitcoinPrices({ prices: "invalid" }), []);
+});

--- a/test/overview.test.js
+++ b/test/overview.test.js
@@ -1,0 +1,36 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const render = require("snabbdom-to-html");
+
+const { overview } = require("../client/src/views/overview");
+
+const t = (parts, ...values) => parts.reduce(
+  (result, part, index) =>
+    result + part + (index < values.length ? values[index] : ""),
+  "",
+);
+
+test("formats the recommended fee rate and dollar estimate", () => {
+  const html = render(overview({
+    blocks: [],
+    feeEst: { 3: 6 },
+    mempool: { vsize: 0 },
+    bitcoinMarketChart: { prices: [[1, 50_000]] },
+    t,
+  }));
+
+  const expectedFeeUsd = process.env.IS_ELEMENTS ? "$0.77 USD" : "$0.42 USD";
+
+  assert.match(
+    html,
+    /Recommended Fee[\s\S]*6 sat\/vB/,
+  );
+  assert(html.includes(expectedFeeUsd), expectedFeeUsd);
+  assert.match(html, /\$50,000\.00 USD/);
+});
+
+test("shows unavailable overview fee and price values explicitly", () => {
+  const html = render(overview({ blocks: [], mempool: null, t }));
+
+  assert.match(html, /Recommended Fee[\s\S]*N\/A[\s\S]*N\/A/);
+});

--- a/test/pending-block-details.test.js
+++ b/test/pending-block-details.test.js
@@ -5,14 +5,11 @@ const {
   formatCount,
   formatEstimatedBlockTime,
   formatFeeBoundary,
-  formatFeeRate,
   formatMegabytes,
   formatPanelPercentage,
   formatPercentage,
   formatTransactionDelta,
-  formatUsd,
   formatWeight,
-  getLatestBitcoinPrice,
 } = require("../client/src/lib/pending-block-details");
 const {
   targetBlockIntervalSeconds,
@@ -62,20 +59,11 @@ test("counts down to and measures time past the expected block interval", () => 
 test("formats pending-block metric values and fallbacks", () => {
   assert.equal(formatPercentage(12.345), "12.35%");
   assert.equal(formatPanelPercentage(12.3), "12.3%");
-  assert.equal(formatFeeRate(2.5), "2.50 sat/vB");
   assert.equal(formatFeeBoundary(2.5), "2.50");
   assert.equal(formatWeight(1_250_000), "1.25 MWU");
   assert.equal(formatMegabytes(2_500_000), "2.5 MB");
   assert.equal(formatCount(12_345), "12,345");
-  assert.equal(formatUsd(1_234.5), "$1,234.50 USD");
   assert.equal(formatPercentage(null, "-"), "-");
-});
-
-test("selects the latest finite market price", () => {
-  assert.equal(getLatestBitcoinPrice({
-    prices: [[1, 100], null, [2, NaN], [3, 125]],
-  }), 125);
-  assert.equal(getLatestBitcoinPrice(null), null);
 });
 
 test("formats pending transaction changes", () => {

--- a/www/style.css
+++ b/www/style.css
@@ -3946,6 +3946,31 @@ a.back-link img{
   gap: 12px;
 }
 
+.fee-market {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.fee-market-body {
+  display: flex;
+  gap: var(--page-gap);
+}
+
+.fee-market .info-card-container {
+  flex: 1;
+  width: auto;
+  min-width: 0;
+}
+
+.fee-market-low .info-card-value {
+  color: var(--success-color);
+}
+
+.fee-market-high .info-card-value {
+  color: var(--danger-color);
+}
+
 .info-stats-row {
   display: flex;
   gap: 12px;
@@ -5664,6 +5689,14 @@ a.back-link img{
 @media only screen and (max-width: 1328px) {
   .dashboard-transaction-section {
     flex-direction: column;
+  }
+
+  .fee-market-body {
+    flex-wrap: wrap;
+  }
+
+  .fee-market .info-card-container {
+    flex-basis: 260px;
   }
 }
 


### PR DESCRIPTION
To run locally, npm install and use the following snippets:
```
# Bitcoin
export API_URL=https://blockstream.info/api
export PORT=4999
source flavors/blockstream/config.env
source flavors/bitcoin-mainnet/config.env
npm run dev-server
```

```
# Liquid
export API_URL=https://blockstream.info/liquid/api
export PORT=5000
source flavors/blockstream/config.env
source flavors/liquid-mainnet/config.env
npm run dev-server
```

---

Bitcoin:
<img width="1728" height="1117" alt="fee btc | Screenshot 2026-08-13 at 11 58 37 AM" src="https://github.com/user-attachments/assets/1e61b02c-c56a-4596-8d50-81ad7a163c1e" />

Liquid:
<img width="1728" height="1117" alt="fee lqd | Screenshot 2026-08-13 at 11 58 06 AM" src="https://github.com/user-attachments/assets/be5fa40c-4637-4640-8631-602f7cbd8de2" />
