### PR TITLE
Fixed explorer UI and polling issues.

### DIFF
--- a/client/src/app.js
+++ b/client/src/app.js
@@ -30,6 +30,11 @@ import * as views from './views'
 
 const apiBase = (process.env.API_URL || '/api').replace(/\/+$/, '')
     , bitcoinMarketChartUrl = process.env.BITCOIN_MARKET_CHART_URL || 'https://api.coingecko.com/api/v3/coins/bitcoin/market_chart?vs_currency=usd&days=1&interval=hourly'
+    , blockTemplatePollIntervalMs = 30000
+    // Wait one electrs cache window after a new tip before requesting the next
+    // template. If a refresh is still in progress, electrs holds the request
+    // until fresh data is ready, so no additional client-side jitter is needed.
+    , blockTemplatePollAfterNewBlockMs = 15000
     , setBase = ({ path, ...r }) => ({ ...r, url: path.includes('://') || path.startsWith('./') ? path : apiBase + path })
 
 const reservedPaths = [ 'mempool', 'assets', 'search' ]
@@ -72,6 +77,32 @@ const trackNewEntries = (items$, getId, getNewIds=defaultNewIds) => {
     .startWith(current => current)
     .scan((current, mod) => mod(current), {})
 }
+
+export const scheduleBlockTemplatePolls = (start$, newBlock$, scheduler) =>
+  O.merge(
+    start$.mapTo(0),
+    newBlock$.mapTo(blockTemplatePollAfterNewBlockMs)
+  )
+    .switchMap(delay => O.timer(
+      delay,
+      blockTemplatePollIntervalMs,
+      scheduler
+    ))
+
+export const scheduleDashboardBlockTemplatePolls = (
+  view$,
+  newBlock$,
+  scheduler
+) => scheduleBlockTemplatePolls(
+  view$
+    .distinctUntilChanged()
+    .filter(view => view == 'dashBoard'),
+  newBlock$,
+  scheduler
+)
+  .withLatestFrom(view$, (pollIndex, view) => ({ pollIndex, view }))
+  .filter(({ view }) => view == 'dashBoard')
+  .map(({ pollIndex }) => pollIndex)
 
 const trackPendingBlockTemplateUpdate = (previous, template) => {
   if (!template || !Array.isArray(template.transactions)) {
@@ -283,6 +314,11 @@ export default function main({ DOM, HTTP, route, storage, scanner: scan$, search
   , tx$ = reply('tx').merge(goTx$.mapTo(null)).startWith(null)
   , txBlock$ = reply('tx-block').merge(goTx$.mapTo(null)).startWith(null)
 
+  // Predecessor metadata for confirmed block interval calculations
+  , previousBlock$ = reply('previous-block')
+      .merge(O.merge(goBlock$, goTx$).mapTo(null))
+      .startWith(null)
+
   // Currently collapsed tx/block ("details")
   , openTx$ = togTx$.startWith(null).scan((prev, txid) => prev == txid ? null : txid)
   , openBlock$ = togBlock$.startWith(null).scan((prev, blockhash) => prev == blockhash ? null : blockhash)
@@ -422,6 +458,18 @@ export default function main({ DOM, HTTP, route, storage, scanner: scan$, search
           .distinctUntilChanged((a, b) => a.height == b.height)
       : O.empty()
 
+  , dashboardNewBlock$ = latestBlock$.skip(1)
+      .withLatestFrom(view$)
+      .filter(([ _, view ]) => view == 'dashBoard')
+
+  // In the browser, wait for the ready dashboard view. Liquid remains in the
+  // loading view until its asset map arrives, so starting from goHome$ would
+  // discard the initial template request.
+  , blockTemplatePoll$ = !process.browser
+      ? goHome$
+      : scheduleDashboardBlockTemplatePolls(view$, dashboardNewBlock$)
+          .filter(pollIndex => pollIndex == 0 || document.hasFocus())
+
   , dashboardEpochStartHeight$ = dashboardLatestBlock$
       .map(block => block.height - (block.height % difficultyPeriod))
       .distinctUntilChanged()
@@ -451,7 +499,7 @@ export default function main({ DOM, HTTP, route, storage, scanner: scan$, search
                      , newBlockEntries$, newTxEntries$
                      , goBlock$, block$, blockStatus$, blockTxs$, nextBlockTxs$, prevBlockTxs$, openBlock$
                      , mempool$, mempoolRecent$, feeEst$, bitcoinMarketChart$
-                     , tx$, txBlock$, txAnalysis$, openTx$
+                     , tx$, txBlock$, previousBlock$, txAnalysis$, openTx$
                      , goAddr$, addr$, addrTxs$, addrQR$
                      , assetMap$, assetList$, goAssetList$, goAsset$, asset$, assetTxs$, unblinded$
                      , isReady$, loading$, page$, view$, title$
@@ -482,6 +530,11 @@ export default function main({ DOM, HTTP, route, storage, scanner: scan$, search
     // fetch the block containing a confirmed tx
     , tx$.filter(tx         => tx && tx.status && tx.status.confirmed && tx.status.block_hash)
         .map(tx             => ({ category: 'tx-block',   method: 'GET', path: `/block/${tx.status.block_hash}` }))
+
+    // fetch the predecessor needed to calculate a confirmed block's interval
+    , O.merge(block$, txBlock$)
+        .filter(block       => block && block.previousblockhash)
+        .map(block          => ({ category: 'previous-block', method: 'GET', path: `/block/${block.previousblockhash}`, bg: true }))
 
     // fetch address and its txs
     , goAddr$.flatMap(d     => [{ category: 'address',    method: 'GET', path: `/address/${d.addr}` }
@@ -563,14 +616,9 @@ export default function main({ DOM, HTTP, route, storage, scanner: scan$, search
                               , { category: 'dashboard-peg-chain-txs', method: 'GET', path: `/asset/${nativeAssetId}/txs/chain`, bg: true }
                               , { category: 'dashboard-peg-mempool-txs', method: 'GET', path: `/asset/${nativeAssetId}/txs/mempool`, bg: true }]))
 
-    // refresh the pending block template while the dashboard remains open
-    , O.merge(
-        O.merge(goHome$, tickWhileViewing(30000, 'dashBoard', view$))
-          .throttleTime(1000)
-      , latestBlock$.skip(1)
-          .withLatestFrom(view$)
-          .filter(([ _, view ]) => view == 'dashBoard')
-      )
+    // Refresh the pending block template while the dashboard remains open. A new
+    // tip resets the cadence and waits for electrs' block cache to refresh.
+    , blockTemplatePoll$
         .mapTo({ category: 'block-template', method: 'GET', path: '/block-template', bg: true })
 
     , goHome$.flatMap(_ =>  [{ category: 'blocks',    method: 'GET', path: '/blocks' }
@@ -670,7 +718,22 @@ export default function main({ DOM, HTTP, route, storage, scanner: scan$, search
     })
 
     on('.table-copy-button', 'click', { preventDefault: true }).subscribe(e => e.stopPropagation())
-    on('.tooltip', 'click', { preventDefault: true }).subscribe(e => e.stopPropagation())
+
+    const closeOpenTooltips = except => {
+      document.querySelectorAll('.tooltip.tooltip-open').forEach(tooltip => {
+        if (tooltip != except) tooltip.classList.remove('tooltip-open')
+      })
+    }
+    on('.tooltip', 'click', { preventDefault: true }).subscribe(e => {
+      e.stopPropagation()
+      const tooltip = e.ownerTarget
+          , shouldOpen = !tooltip.classList.contains('tooltip-open')
+      closeOpenTooltips(tooltip)
+      tooltip.classList.toggle('tooltip-open', shouldOpen)
+      if (!shouldOpen) tooltip.blur()
+    })
+    on('.tooltip', 'blur').subscribe(({ ownerTarget: tooltip }) =>
+      tooltip.classList.remove('tooltip-open'))
     on('[data-scroll-top]', 'click').subscribe(_ => window.scrollTo(0, 0))
 
     const keepTooltipInViewport = ({ ownerTarget: tooltip }) => {
@@ -709,6 +772,7 @@ export default function main({ DOM, HTTP, route, storage, scanner: scan$, search
       if (activeTooltip && activeTooltip.classList.contains('tooltip') && !e.target.closest('.tooltip')) {
         activeTooltip.blur()
       }
+      if (!e.target.closest('.tooltip')) closeOpenTooltips()
       if (e.target.closest('.main-nav-container')) return
       closeNetworkMenus()
     })
@@ -716,6 +780,7 @@ export default function main({ DOM, HTTP, route, storage, scanner: scan$, search
     document.addEventListener('keydown', e => {
       if (e.key == 'Escape') {
         closeNetworkMenus()
+        closeOpenTooltips()
         document.activeElement && document.activeElement.classList.contains('tooltip') && document.activeElement.blur()
       }
 

--- a/client/src/components/block-details-card.js
+++ b/client/src/components/block-details-card.js
@@ -4,7 +4,7 @@ import { InfoStat } from "./info-stat";
 import { MinusIcon, PlusIcon } from "./icons";
 import { MetricBar } from "./metric-bar";
 import { StatusBadge } from "./status-badge";
-import { ElapsedTime } from "./elapsed-time";
+import { ElapsedTime, formatDuration } from "./elapsed-time";
 import { Tooltip } from "./tooltip";
 import { maxBlockWeight } from "../const";
 import {
@@ -42,16 +42,34 @@ const formatVirtualSize = (weight) => {
   return formatScaledValue(virtualSize, 1_000_000, "vMB");
 };
 
-const ExpandedBlockDetails = ({ block, t }) => {
+const formatBlockInterval = (block, previousBlock) => {
+  if (
+    !block ||
+    !previousBlock ||
+    previousBlock.id !== block.previousblockhash ||
+    !Number.isFinite(block.timestamp) ||
+    !Number.isFinite(previousBlock.timestamp)
+  ) {
+    return "N/A";
+  }
+
+  return formatDuration(
+    (block.timestamp - previousBlock.timestamp) * 1000,
+    true,
+  );
+};
+
+const ExpandedBlockDetails = ({ block, previousBlock, t }) => {
   const weightPercentage = getBlockPercentageUsed(block.weight);
+  const blockInterval = formatBlockInterval(block, previousBlock);
 
   return (
     <div id="expanded-block-details" className="expanded-block-details">
       <InfoCard
         className="block-detail-time-panel"
         title={t`Time Since Last Block`}
-        tooltip={t`Time elapsed since this block was mined.`}
-        value={<ElapsedTime timestamp={block.timestamp} compact />}
+        tooltip={t`Time elapsed between this block and the previous block.`}
+        value={blockInterval}
         footer={t`Block #${block.height.toLocaleString()}`}
       />
       <InfoCard
@@ -128,6 +146,7 @@ const BlockDetailsCard = ({
   className,
   block,
   detailsOpen = false,
+  previousBlock,
   statusText,
   statusVariant = "success",
   t,
@@ -135,6 +154,7 @@ const BlockDetailsCard = ({
   const percentage = block
     ? Math.min(Math.max(getBlockPercentageUsed(block.weight), 0), 100)
     : 0;
+  const blockInterval = formatBlockInterval(block, previousBlock);
 
   return (
     <div
@@ -196,13 +216,7 @@ const BlockDetailsCard = ({
           <div className="block-details-card-stats">
             <InfoStat
               title={t`Time Since Last Block`}
-              value={
-                block ? (
-                  <ElapsedTime timestamp={block.timestamp} compact />
-                ) : (
-                  "N/A"
-                )
-              }
+              value={blockInterval}
             />
             <InfoStat
               title={t`Transactions`}
@@ -243,7 +257,13 @@ const BlockDetailsCard = ({
         </div>
       </div>
 
-      {detailsOpen && block ? <ExpandedBlockDetails block={block} t={t} /> : null}
+      {detailsOpen && block ? (
+        <ExpandedBlockDetails
+          block={block}
+          previousBlock={previousBlock}
+          t={t}
+        />
+      ) : null}
     </div>
   );
 };

--- a/client/src/components/elapsed-time.js
+++ b/client/src/components/elapsed-time.js
@@ -3,12 +3,10 @@ const MINUTES_PER_DAY = 24 * 60;
 const MINUTES_PER_YEAR = 365 * MINUTES_PER_DAY;
 const MINUTES_PER_MONTH = MINUTES_PER_YEAR / 12;
 
-const formatElapsedTime = (timestamp, compact) => {
-  const fromDate =
-    timestamp < 1e12 ? new Date(timestamp * 1000) : new Date(timestamp);
+export const formatDuration = (durationMilliseconds, compact = false) => {
   const diffMinutes = Math.max(
     0,
-    Math.floor((new Date() - fromDate) / UPDATE_INTERVAL_MS),
+    Math.floor(durationMilliseconds / UPDATE_INTERVAL_MS),
   );
   const years = Math.floor(diffMinutes / MINUTES_PER_YEAR);
   const minutesAfterYears = diffMinutes % MINUTES_PER_YEAR;
@@ -39,7 +37,17 @@ const formatElapsedTime = (timestamp, compact) => {
 
   if (compact) return parts.length ? parts.join(" ") : "< 1m";
 
-  return parts.length ? `${parts.join(" ")} AGO` : "< 1 MINUTE AGO";
+  return parts.length ? parts.join(" ") : "< 1 MINUTE";
+};
+
+const formatElapsedTime = (timestamp, compact) => {
+  const fromDate =
+    timestamp < 1e12 ? new Date(timestamp * 1000) : new Date(timestamp);
+  const duration = formatDuration(new Date() - fromDate, compact);
+
+  if (compact) return duration;
+
+  return `${duration} AGO`;
 };
 
 const updateElapsedTime = (element) => {

--- a/client/src/views/asset-list.js
+++ b/client/src/views/asset-list.js
@@ -46,23 +46,31 @@ export default ({ assetList, goAssetList, loading, t, ...S }) => {
             <div className={`asset-list-body ${loading ? "asset-list-body-loading" : ""}`}>
               {assets.map((asset) => (
                 <a href={`asset/${asset.asset_id}`}>
-                <div className="assets-table-link-row">
-                  <div className="assets-table-row">
-                    <div className="asset-list-name" data-label={t`Name`}>
-                      <CurrencyDollarIcon className="currency-dollar" />
-                      {asset.name}
-                    </div>
-                    <div className="asset-list-ticker" data-label={t`Ticker`}>
-                      {asset.ticker || <em>None</em>}
-                    </div>
-                    <div className="asset-list-total-supply" data-label={t`Total Supply`}>
-                      {getSupply(asset, t)}
-                    </div>
-                    <div className="asset-list-issuer-domain" data-label={t`Issuer domain`}>
-                      {asset.entity.domain}
+                  <div className="assets-table-link-row">
+                    <div className="assets-table-row">
+                      <div className="asset-list-name" data-label={t`Name`}>
+                        <span className="asset-list-field-value">
+                          <CurrencyDollarIcon className="currency-dollar" />
+                          {asset.name}
+                        </span>
+                      </div>
+                      <div className="asset-list-ticker" data-label={t`Ticker`}>
+                        <span className="asset-list-field-value">
+                          {asset.ticker || <em>None</em>}
+                        </span>
+                      </div>
+                      <div className="asset-list-total-supply" data-label={t`Total Supply`}>
+                        <span className="asset-list-field-value">
+                          {getSupply(asset, t)}
+                        </span>
+                      </div>
+                      <div className="asset-list-issuer-domain" data-label={t`Issuer domain`}>
+                        <span className="asset-list-field-value">
+                          {asset.entity.domain}
+                        </span>
+                      </div>
                     </div>
                   </div>
-                </div>
                 </a>
               ))}
             </div>

--- a/client/src/views/asset.js
+++ b/client/src/views/asset.js
@@ -157,7 +157,7 @@ export default ({ t, asset, assetTxs, goAsset, openTx, spends, tipHeight, loadin
                 {detailField(
                   'ISSUER PUBKEY',
                   contract.issuer_pubkey,
-                  'mono',
+                  null,
                   t,
                   shortenValue(contract.issuer_pubkey)
                 )}

--- a/client/src/views/block.js
+++ b/client/src/views/block.js
@@ -25,6 +25,7 @@ export default ({
   tipHeight,
   loading,
   page,
+  previousBlock,
   txsStatus = makeStatus(b),
   ...S
 }) =>
@@ -60,6 +61,7 @@ export default ({
           </div>
           <BlockDetailsCard
             block={b}
+            previousBlock={previousBlock}
             t={t}
             detailsOpen={S.openBlock === b.id}
             statusText={

--- a/client/src/views/footer.js
+++ b/client/src/views/footer.js
@@ -33,7 +33,7 @@ const resourceLinks = [
   ['Bitcoin Education', 'https://help.blockstream.com/education/'],
   ['Glossary', 'https://help.blockstream.com/education/glossary/'],
   ['Local', 'https://blockstream.com/local/'],
-  ['Brand Assets', 'https://design.blockstream.com/styleguide/branding/overview/']
+  ['Brand Assets', 'https://design.blockstream.com/styleguide/branding/overview.html']
 ]
 
 const socialLinks = [

--- a/client/src/views/nav-toggle.js
+++ b/client/src/views/nav-toggle.js
@@ -45,8 +45,8 @@ export default () =>
           <ul className="font-p3">
             <li><a href={`${siteRoot}/`} rel="external">Bitcoin</a></li>
             <li><a href={`${siteRoot}/liquid/`} rel="external">Liquid Network</a></li>
-            <li><a href={`${siteRoot}/testnet/`} rel="external" target="_blank">Bitcoin Testnet</a></li>
-            <li><a href={`${siteRoot}/liquidtestnet/`} rel="external" target="_blank">Liquid Testnet</a></li>
+            <li><a href={`${siteRoot}/testnet/`} rel="external">Bitcoin Testnet</a></li>
+            <li><a href={`${siteRoot}/liquidtestnet/`} rel="external">Liquid Testnet</a></li>
           </ul>
           <h4 className="menu-title font-h5">Developer Tools</h4>
           <ul className="font-p3">

--- a/client/src/views/overview.js
+++ b/client/src/views/overview.js
@@ -4,6 +4,7 @@ import { InfoCard } from "../components/info-card";
 import { MempoolCongestion } from "../components/mempool-congestion";
 import { ReferenceLineChart } from "../components/reference-line-chart";
 import { estimateTypicalTransactionFeeUsd } from "../lib/fees";
+import { isBitcoinNetwork } from "../lib/network";
 import {
   getBitcoinPrices,
   getLatestBitcoinPrice,
@@ -37,7 +38,11 @@ export const overview = ({
       <div className="overview-body">
         <InfoCard
           title={t`Time since last block`}
-          tooltip={t`Elapsed time since the last block confirmed. Bitcoin targets one every ~10 minutes.`}
+          tooltip={
+            isBitcoinNetwork
+              ? t`Elapsed time since the last block confirmed. Bitcoin targets one every ~10 minutes.`
+              : t`Elapsed time since the last block confirmed. Liquid targets one every ~1 minute.`
+          }
           value={
             latestBlock ? (
               <ElapsedTime timestamp={latestBlock.timestamp} compact />

--- a/client/src/views/tx.js
+++ b/client/src/views/tx.js
@@ -45,6 +45,7 @@ export default ({
   page,
   unblinded,
   txBlock,
+  previousBlock,
   ...S
 }) => {
   if (!tx || !S.txAnalysis) return;
@@ -93,6 +94,7 @@ export default ({
             <BlockDetailsCard
               className="transaction-block-details"
               block={block}
+              previousBlock={previousBlock}
               t={t}
               detailsOpen={block && S.openBlock === block.id}
               statusText={t`Confirmed`}

--- a/flavors/liquid/extras.css
+++ b/flavors/liquid/extras.css
@@ -133,14 +133,32 @@
 }
 
 .asset-list-issuer-domain {
-  text-decoration: underline !important;
+  text-decoration: none !important;
 }
 
 .asset-list-name {
   display: flex;
   align-items: center;
   gap: 11px;
-  text-decoration: underline !important;
+  text-decoration: none !important;
+}
+
+.asset-list-name .asset-list-field-value,
+.asset-list-issuer-domain .asset-list-field-value {
+  text-decoration: underline;
+}
+
+.asset-list-field-value {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.asset-list-name .asset-list-field-value {
+  display: flex;
+  align-items: center;
+  gap: 11px;
 }
 
 .asset-list-name .currency-dollar {
@@ -302,73 +320,74 @@
 
 /***************************/
 
-@media only screen and (max-width: 850px) {
+/* ASSET TABLE COMPACT */
 
-    /* assets table */
-
-    .asset-label{
-      width: 40%;
-    }
-
-    .asset-text{
-      text-align: right;
-      width: 60%;
-    }
-
-    div.assets-table-row.header .supply{
-      display:none;
-    }
-
-    div.assets-table-row.header .domain{
-      width: 50%;
-    }
-
-    /* table row (asset) */
-    .assets-table-row {
-      margin: 0 0 1rem 0;
-      display: flex;
-      flex-direction: column;
-      height: auto !important;
-      padding: 20px;
-    }
-
-    .assets-table-link-row {
-      margin-bottom: 20px;
-    }
-
-    .assets-table-link-row:nth-child(odd) {
-      background: #22242c;
-    }
-
-    .assets-table-row {
-      /* Behave  like a "row" */
-      display: block;
-    }
-}
-
-
-
-
-/* ASSET TABLE MOBILE */
-
-
-/* Pagination remove numbers on Mobile - show Next and Prev instead */
-@media only screen and (max-width: 500px) {
-  .pagination .numbers{
+@media only screen and (max-width: 1328px) {
+  .asset-container > .table-title-row {
     display: none;
   }
-  .pagination .next, .pagination .prev{
-    width: 85px;
+
+  .assets-table-row {
+    flex-direction: column;
+    padding: 12px;
+    gap: 12px;
+  }
+
+  .asset-list-name,
+  .asset-list-ticker,
+  .asset-list-total-supply,
+  .asset-list-issuer-domain {
     display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 24px;
+    overflow: visible;
+    white-space: normal;
+    text-align: right;
   }
-  .pagination .next::before {
-    content: "Next";
-    line-height: 1.7;
-    padding: 0 4px;
+
+  .asset-list-name::before,
+  .asset-list-ticker::before,
+  .asset-list-total-supply::before,
+  .asset-list-issuer-domain::before {
+    content: attr(data-label);
+    flex: 0 0 auto;
+    color: #B5BDC2;
+    font-size: 10px;
+    font-weight: 400;
+    text-align: left;
+    text-transform: uppercase;
   }
-  .pagination .prev::after {
-    content: "Prev";
-    line-height: 1.7;
-    padding: 0 4px;
+
+  .asset-list-field-value,
+  .asset-list-name .asset-list-field-value {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    min-width: 0;
+    overflow: visible;
+    overflow-wrap: anywhere;
+    white-space: normal;
+  }
+
+  .asset-list-pagination {
+    flex-wrap: wrap;
+  }
+
+  .pagination-dropdown-container {
+    flex: 1 1 260px;
+    flex-wrap: wrap;
+  }
+
+  .pagination {
+    flex: 1 1 360px;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  .pagination .numbers {
+    flex-wrap: wrap;
   }
 }

--- a/lang/strings.txt
+++ b/lang/strings.txt
@@ -181,7 +181,7 @@ This transaction saved %s on fees by upgrading to native SegWit-Bech32
 This transaction saved %s on fees by upgrading to SegWit and could save %s more by fully upgrading to native SegWit-Bech32
 Ticker
 Time Since Last Block
-Time elapsed since this block was mined.
+Time elapsed between this block and the previous block.
 %s MINUTE PAST EXPECTED INTERVAL
 %s MINUTES PAST EXPECTED INTERVAL
 Timestamp

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -1,5 +1,9 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
+const { Subject } = require("../client/node_modules/rxjs/Subject");
+const {
+  TestScheduler,
+} = require("../client/node_modules/rxjs/testing");
 
 process.env.IS_ELEMENTS = "1";
 process.env.MENU_ACTIVE = "Liquid";
@@ -10,6 +14,8 @@ const {
 } = require("../client/src/const");
 const {
   default: main,
+  scheduleBlockTemplatePolls,
+  scheduleDashboardBlockTemplatePolls,
   trackPendingBlockTemplateEvent,
 } = require("../client/src/app");
 
@@ -30,8 +36,28 @@ const makeRoute = () => {
   return route;
 };
 
+const makeBlockRoute = (hash) => {
+  const location = {
+    hash: "",
+    key: "block",
+    params: { hash },
+    pathname: `/block/${hash}`,
+    query: {},
+  };
+  const location$ = O.of(location);
+  const route = (pattern) =>
+    pattern === undefined || pattern === "/block/:hash"
+      ? location$
+      : empty$;
+
+  route.all$ = location$;
+  return route;
+};
+
 const makeSources = ({
   blockGridEvent$ = empty$,
+  responseStreams = {},
+  route = makeRoute(),
   selectedCategories = [],
 } = {}) => ({
   DOM: {
@@ -47,11 +73,11 @@ const makeSources = ({
   HTTP: {
     select: (category) => {
       selectedCategories.push(category);
-      return empty$;
+      return responseStreams[category] || empty$;
     },
   },
   blinding: empty$,
-  route: makeRoute(),
+  route,
   scanner: empty$,
   search: empty$,
   storage: {
@@ -81,6 +107,65 @@ test("requests and consumes block templates on an Elements dashboard", () => {
   ]);
 });
 
+test("delays a new-tip poll and resets the regular template cadence", () => {
+  const scheduler = new TestScheduler((actual, expected) =>
+    assert.deepEqual(actual, expected));
+  const start$ = new Subject();
+  const newBlock$ = new Subject();
+  const polls = [];
+
+  scheduler.maxFrames = 57_000;
+  scheduleBlockTemplatePolls(start$, newBlock$, scheduler)
+    .subscribe((pollIndex) => polls.push([scheduler.frame, pollIndex]));
+  scheduler.schedule(() => start$.next(), 0);
+  scheduler.schedule(() => newBlock$.next(), 12_000);
+  scheduler.flush();
+
+  assert.deepEqual(polls, [
+    [0, 0],
+    [27_000, 0],
+    [57_000, 1],
+  ]);
+});
+
+test("starts template polling when a delayed Liquid dashboard becomes ready", () => {
+  const scheduler = new TestScheduler((actual, expected) =>
+    assert.deepEqual(actual, expected));
+  const view$ = new Subject();
+  const newBlock$ = new Subject();
+  const polls = [];
+
+  scheduler.maxFrames = 1_000;
+  scheduleDashboardBlockTemplatePolls(view$, newBlock$, scheduler)
+    .subscribe((pollIndex) => polls.push([scheduler.frame, pollIndex]));
+  scheduler.schedule(() => view$.next("loading"), 0);
+  scheduler.schedule(() => view$.next("dashBoard"), 250);
+  scheduler.flush();
+
+  assert.deepEqual(polls, [[250, 0]]);
+});
+
+test("restarts template polling when the dashboard is reopened", () => {
+  const scheduler = new TestScheduler((actual, expected) =>
+    assert.deepEqual(actual, expected));
+  const view$ = new Subject();
+  const newBlock$ = new Subject();
+  const polls = [];
+
+  scheduler.maxFrames = 1_000;
+  scheduleDashboardBlockTemplatePolls(view$, newBlock$, scheduler)
+    .subscribe((pollIndex) => polls.push([scheduler.frame, pollIndex]));
+  scheduler.schedule(() => view$.next("dashBoard"), 0);
+  scheduler.schedule(() => view$.next("tx"), 250);
+  scheduler.schedule(() => view$.next("dashBoard"), 500);
+  scheduler.flush();
+
+  assert.deepEqual(polls, [
+    [0, 0],
+    [500, 0],
+  ]);
+});
+
 test("navigates a selected pending-block transaction in app history", () => {
   const txid = "a".repeat(64);
   const routeUpdates = [];
@@ -96,6 +181,27 @@ test("navigates a selected pending-block transaction in app history", () => {
       pathname: `/tx/${txid}`,
     },
   ]);
+});
+
+test("requests predecessor metadata for confirmed block intervals", () => {
+  const hash = "a".repeat(64);
+  const previousHash = "b".repeat(64);
+  const blockResponses = new Subject();
+  const requests = [];
+  const sources = makeSources({
+    responseStreams: { block: blockResponses },
+    route: makeBlockRoute(hash),
+  });
+
+  main(sources).HTTP.subscribe((request) => requests.push(request));
+  blockResponses.next(O.of({
+    body: { id: hash, previousblockhash: previousHash },
+  }));
+
+  assert.ok(requests.some((request) =>
+    request.category === "previous-block" &&
+    request.url === `/api/block/${previousHash}`
+  ));
 });
 
 test("ignores block template responses for an older tip", () => {

--- a/test/block-details-card.test.js
+++ b/test/block-details-card.test.js
@@ -23,6 +23,7 @@ const t = (parts, ...values) => parts.reduce(
 const block = {
   id: "a".repeat(64),
   height: 100,
+  previousblockhash: "c".repeat(64),
   timestamp: 1_700_000_000,
   tx_count: 2,
   size: 1_000_000,
@@ -30,6 +31,11 @@ const block = {
   version: 1,
   nonce: 2,
   merkle_root: "b".repeat(64),
+};
+
+const previousBlock = {
+  id: block.previousblockhash,
+  timestamp: block.timestamp - 10 * 60,
 };
 
 const emptyTemplateMetrics = {
@@ -85,7 +91,7 @@ test("passes block detail copy through localization", () => {
     "Number of transactions included in this block.",
     "Size",
     "Time Since Last Block",
-    "Time elapsed since this block was mined.",
+    "Time elapsed between this block and the previous block.",
     "Transactions",
     "Version",
     "Version bits recorded in the block header.",
@@ -130,6 +136,17 @@ test("disables block details until block metadata is available", () => {
     html,
     /class="block-details-card-details-button"[^>]*disabled="disabled"/,
   );
+});
+
+test("shows the interval from the displayed block to its predecessor", () => {
+  const html = render(BlockDetailsCard({
+    block,
+    detailsOpen: true,
+    previousBlock,
+    t,
+  }));
+
+  assert.equal((html.match(/>10m</g) || []).length, 2);
 });
 
 test("shows the pending transaction live badge only with template data", () => {

--- a/www/style.css
+++ b/www/style.css
@@ -2590,7 +2590,7 @@ dl.mempool-histogram .bar:before {
 }
 
 .toggle-menu .section1 .wallets-link .store-icons a:hover{
-  color: #00ccff;
+  color: var(--accent-color);
 }
 
 .toggle-menu .section1, .toggle-menu .section2{
@@ -2619,7 +2619,7 @@ dl.mempool-histogram .bar:before {
 }
 
 .toggle-menu .section2 a:hover{
-  color: #00ccff;
+  color: var(--accent-color);
 }
 
 .sub-navbar{
@@ -3502,7 +3502,8 @@ a.back-link img{
 }
 
 .tooltip:hover .tooltip-dialogue,
-.tooltip:focus .tooltip-dialogue {
+.tooltip:focus .tooltip-dialogue,
+.tooltip.tooltip-open .tooltip-dialogue {
   display: initial;
 }
 
@@ -4133,7 +4134,7 @@ a.back-link img{
 .mempool-congestion {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 6px;
   margin-top: 10px;
 }
 
@@ -4814,12 +4815,32 @@ a.back-link img{
   border-radius: var(--max-border-radius);
 }
 
-@media only screen and (max-width: 820px) {
+@media only screen and (max-width: 1328px) {
   .asset-table {
-    align-items: flex-start;
+    display: grid;
+    grid-template-columns: 80px minmax(0, 1fr);
+    align-items: center;
+  }
+
+  .asset-table-body {
+    display: contents;
+  }
+
+  .asset-icon-container {
+    grid-column: 1;
+    grid-row: 1;
+  }
+
+  .asset-title-row {
+    grid-column: 2;
+    grid-row: 1;
+    min-width: 0;
+    flex-wrap: wrap;
   }
 
   .asset-table-details {
+    grid-column: 1 / -1;
+    grid-row: 2;
     align-items: flex-start;
     flex-direction: column;
   }
@@ -4953,7 +4974,7 @@ a.back-link img{
 
 .pending-block-container {
   width: 100%;
-  --pending-block-grid-size: 580px;
+  --pending-block-grid-size: 559px;
   height: var(--pending-block-grid-size);
   box-sizing: border-box;
   padding: 8px;


### PR DESCRIPTION
To run locally, npm install and use the following snippets:
```
# Bitcoin
export API_URL=https://blockstream.info/api
export PORT=4999
source flavors/blockstream/config.env
source flavors/bitcoin-mainnet/config.env
npm run dev-server
```

```
# Liquid
export API_URL=https://blockstream.info/liquid/api
export PORT=5000
source flavors/blockstream/config.env
source flavors/liquid-mainnet/config.env
npm run dev-server
```

---

- Corrected the Brand Assets footer URL and kept testnet explorer links in the same tab.
<img width="552" height="386" alt="brand asset link | Screenshot 2026-08-16 at 12 56 00 PM" src="https://github.com/user-attachments/assets/e6fcbbd5-bb58-4910-b34b-3987ad85eba1" />
<img width="394" height="404" alt="open in new tab | Screenshot 2026-08-16 at 1 00 49 PM" src="https://github.com/user-attachments/assets/d8799126-2c0b-413d-bc04-95f7f540c7a0" />

---

- Updated the Liquid block-time tooltip and made help tooltips accessible on mobile.
<img width="452" height="188" alt="lqd tooltip | Screenshot 2026-08-16 at 1 04 28 PM" src="https://github.com/user-attachments/assets/2db9c073-7dd9-46a3-9ba6-96294573043f" />

---

- Reworked mobile asset tables, wrapped pagination controls, and aligned asset icons with titles.
<img width="899" height="482" alt="mobile asset table | Screenshot 2026-08-16 at 1 05 21 PM" src="https://github.com/user-attachments/assets/a3513ebf-c367-42c7-ba37-ced3ac996136" />

---

- Matched issuer public-key typography with the other asset details.
<img width="1260" height="145" alt="issuer pubkey formatting | Screenshot 2026-08-16 at 1 06 02 PM" src="https://github.com/user-attachments/assets/82d6c24a-5d1d-4297-96cf-4b58cc9e4945" />

---

- Updated the pending block grid width to 559px.

Before:
<img width="1261" height="662" alt="grid resize (before) | Screenshot 2026-08-16 at 1 06 56 PM" src="https://github.com/user-attachments/assets/32141a7c-ccae-4812-a082-81ef4164c9b1" />
After:
<img width="1253" height="634" alt="grid resize (after) | Screenshot 2026-08-16 at 1 06 34 PM" src="https://github.com/user-attachments/assets/2c1df639-52bb-48ee-86a5-4826efc7fb53" />

---

- Delayed block-template refreshes by 15 seconds after new tips and reset the regular polling cadence.
- Added coverage for the updated block-template polling schedule.