### PR TITLE
Removed pending block status badge and stale hamburger menu links.

### DIFF
--- a/client/src/views/nav-toggle.js
+++ b/client/src/views/nav-toggle.js
@@ -60,9 +60,7 @@ export default () =>
           <h4 className="menu-title font-h5">Other Products</h4>
           <ul className="font-p3">
             <li><a href="https://blockstream.com/liquid/" target="_blank">Liquid Network</a></li>
-            <li><a href="https://blockstream.com/mining/" target="_blank">Blockstream Mining</a></li>
             <li><a href="https://blockstream.com/amp/" target="_blank">Blockstream AMP</a></li>
-            <li><a href="https://blockstream.com/satellite/" target="_blank">Blockstream Satellite</a></li>
             <li><a href="https://blockstream.com/cryptofeed/" target="_blank">Crypto Data Feed</a></li>
             <li><a href="https://blockstream.com/lightning/" target="_blank">Core Lightning</a></li>
             <li><a href="https://blockstream.com/elements/" target="_blank">Elements</a></li>

--- a/client/src/views/pending-block-details-card.js
+++ b/client/src/views/pending-block-details-card.js
@@ -402,16 +402,6 @@ const PendingBlockDetailsCard = ({
               ) : (
                 "-"
               )}
-              <StatusBadge variant={blockTemplate ? "success" : undefined}>
-                {blockTemplate ? <StatusDot /> : null}
-                <span>
-                  {blockTemplate
-                    ? process.env.IS_ELEMENTS
-                      ? t`Building...`
-                      : t`Mining...`
-                    : t`Updating...`}
-                </span>
-              </StatusBadge>
             </p>
             <button
               aria-expanded={detailsOpen ? "true" : "false"}

--- a/lang/strings.txt
+++ b/lang/strings.txt
@@ -91,7 +91,6 @@ Low
 Lock time
 ltr
 Mempool
-Mining...
 Merkle root
 N/A
 New asset

--- a/test/block-details-card.test.js
+++ b/test/block-details-card.test.js
@@ -177,17 +177,13 @@ test("shows the pending transaction live badge only with template data", () => {
 
   assert.doesNotMatch(unavailableHtml, />Live</);
   assert.match(liveHtml, />Live</);
-  assert.match(
-    liveHtml,
-    process.env.IS_ELEMENTS ? />Building\.\.\.</ : />Mining\.\.\.</,
-  );
   assert.equal(
     (unavailableHtml.match(/class="confirmation-status-dot"/g) || []).length,
     0,
   );
   assert.equal(
     (liveHtml.match(/class="confirmation-status-dot"/g) || []).length,
-    2,
+    1,
   );
 });
 
@@ -270,7 +266,6 @@ test("passes pending block copy through localization", () => {
 
   [
     "Next Block",
-    process.env.IS_ELEMENTS ? "Building..." : "Mining...",
     "Details",
     "SIZE",
     "Block filling",


### PR DESCRIPTION
To run locally, npm install and use the following snippets:
```
# Bitcoin
export API_URL=https://blockstream.info/api
export PORT=4999
source flavors/blockstream/config.env
source flavors/bitcoin-mainnet/config.env
npm run dev-server
```

```
# Liquid
export API_URL=https://blockstream.info/liquid/api
export PORT=5000
source flavors/blockstream/config.env
source flavors/liquid-mainnet/config.env
npm run dev-server
```

---

Bitcoin:
<img width="1728" height="1117" alt="btc | Screenshot 2026-08-19 at 2 59 19 PM" src="https://github.com/user-attachments/assets/8f59d78c-d018-4338-9743-543b60347f7d" />

Liquid:
<img width="1728" height="1117" alt="lqd | Screenshot 2026-08-19 at 2 59 43 PM" src="https://github.com/user-attachments/assets/6c2c6744-1e32-4edc-9edb-f6ef0bcd122e" />
