### PR TITLE
ci: publish versioned Docker Hub tags on release tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ then the main image:
 docker build -t esplora -f contrib/Dockerfile .
 ```
 
-Alternatively, you may use the pre-built [`blockstream/esplora` image](https://hub.docker.com/r/blockstream/esplora) from Docker Hub.
+Alternatively, you may use the pre-built [`blockstream/esplora` image](https://hub.docker.com/r/blockstream/esplora) from Docker Hub. The `latest` tag tracks the `master` branch; release tags (e.g. `esplora_v2.10`) are also published as versioned image tags (e.g. `blockstream/esplora:v2.10`) that can be pinned for reproducible deployments.
 
 ## How to run the explorer for Bitcoin mainnet
 

--- a/gitlab/build.yml
+++ b/gitlab/build.yml
@@ -166,3 +166,60 @@ build_and_push_esplora_latest:
       -t ${IMAGE}:latest
       ${IMAGE}:latest-amd64
       ${IMAGE}:latest-arm64
+
+# Release builds: pushing a git tag like `esplora_v2.10` publishes versioned,
+# pinnable image tags to Docker Hub (`v2.10`, `v2.10-amd64`, `v2.10-arm64`)
+# alongside the `latest` tags that track master.
+.build_esplora_release:
+  stage: build
+  rules:
+    - if: '$CI_COMMIT_TAG =~ /^esplora_v/'
+  before_script:
+    - echo "$DOCKERHUB_PASSWORD" | docker login -u $DOCKERHUB_USER --password-stdin
+    - docker buildx create
+      --driver=docker-container
+      --name=buildkit-builder
+      --use
+      --platform linux/${ARCH}
+  script:
+    - VERSION="${CI_COMMIT_TAG#esplora_}"
+    - docker pull ${IMAGE}:latest-${ARCH} || true
+    - sed -i "s#esplora-base:latest#esplora-base:${BASE_TAG}#" contrib/Dockerfile
+    - docker buildx build
+      --push
+      --platform linux/${ARCH}
+      -f contrib/Dockerfile
+      --build-arg BUILDKIT_INLINE_CACHE=1
+      --build-arg FOOT_HTML='<!-- '"$CI_COMMIT_SHA"' -->'
+      --cache-from ${IMAGE}:latest-${ARCH}
+      -t ${IMAGE}:${VERSION}-${ARCH} .
+build_esplora_release_amd64:
+  extends:
+    - .build_esplora_release
+  variables:
+    ARCH: amd64
+build_esplora_release_arm64:
+  extends:
+    - .build_esplora_release
+  variables:
+    ARCH: arm64
+  tags:
+    - cloud-arm
+build_and_push_esplora_release:
+  stage: build
+  rules:
+    - if: '$CI_COMMIT_TAG =~ /^esplora_v/'
+  variables:
+    # No source checkout needed; we only tag already-built images.
+    GIT_STRATEGY: none
+  needs:
+    - build_esplora_release_amd64
+    - build_esplora_release_arm64
+  before_script:
+    - echo "$DOCKERHUB_PASSWORD" | docker login -u $DOCKERHUB_USER --password-stdin
+  script:
+    - VERSION="${CI_COMMIT_TAG#esplora_}"
+    - docker buildx imagetools create
+      -t ${IMAGE}:${VERSION}
+      ${IMAGE}:${VERSION}-amd64
+      ${IMAGE}:${VERSION}-arm64


### PR DESCRIPTION
## Versioned Docker images via the existing pipeline

Today the GitLab CI pipeline only ever pushes `blockstream/esplora:latest`, so there is no way to pull "the image for release X" so pinning and rollbacks require digests.

This PR adds tag-triggered release jobs to the existing pipeline: pushing a git tag like `esplora_v2.10` builds the image from that tagged commit and publishes:

- `blockstream/esplora:v2.10` — multi-arch manifest (amd64 + arm64)
- `blockstream/esplora:v2.10-amd64`, `blockstream/esplora:v2.10-arm64`

`latest` continues to track `master` exactly as before.

### Design notes

- The release jobs mirror the existing `.build_esplora_latest` jobs (same base-image pin via `BASE_TAG`, same `FOOT_HTML` commit stamp, same buildx/cache setup), so a release build is identical to a master build of the same commit, just with a version tag.
- Runs only on tag pipelines (`$CI_COMMIT_TAG =~ /^esplora_v/`); branch, MR, and trigger pipelines are unaffected.
- Uses the existing Docker Hub credentials, resulting in a single registry, one pipeline, no new secrets or repo settings.

This is the alternative to #629: it delivers the versioned/pinnable images that PR is after, but through the pipeline that already builds and tests our published images, and matching our actual `esplora_vX.YY` tag format.

### Validation

- `gitlab/build.yml` parses as valid YAML; the folded multi-line commands were verified to collapse to the intended shell commands.
- Rule audit: on a tag pipeline, only the three new release jobs match (base jobs require `$CI_COMMIT_BRANCH`, latest/test jobs use `only: branches/master`, the GitHub status jobs require trigger pipelines).
- Not run end-to-end: needs a real `esplora_v*` tag push on the repo that runs CI.