### PR TITLE
fix(ci): prevent base image manifest races

### DIFF
--- a/gitlab/build.yml
+++ b/gitlab/build.yml
@@ -6,6 +6,9 @@
         paths:
           - contrib/Dockerfile.base
           - gitlab/build.yml
+    # Manual repair path: a web-run pipeline on the default branch rebuilds
+    # both architectures and re-creates the multi-arch manifest.
+    - if: '$CI_PIPELINE_SOURCE == "web" && $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH'
   before_script:
     - echo "$DOCKERHUB_PASSWORD" | docker login -u $DOCKERHUB_USER --password-stdin
     - docker buildx create
@@ -42,6 +45,9 @@ build_and_push_esplora_base:
         paths:
           - contrib/Dockerfile.base
           - gitlab/build.yml
+    # Manual repair path: a web-run pipeline on the default branch rebuilds
+    # both architectures and re-creates the multi-arch manifest.
+    - if: '$CI_PIPELINE_SOURCE == "web" && $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH'
   variables:
     # No source checkout needed; we only tag already-built images.
     GIT_STRATEGY: none

--- a/gitlab/build.yml
+++ b/gitlab/build.yml
@@ -1,11 +1,11 @@
 .build_esplora_base:
   stage: build
   rules:
-    - if: $CI_COMMIT_BRANCH
+    - if: '$CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH'
       changes:
         paths:
           - contrib/Dockerfile.base
-        compare_to: master
+          - gitlab/build.yml
   before_script:
     - echo "$DOCKERHUB_PASSWORD" | docker login -u $DOCKERHUB_USER --password-stdin
     - docker buildx create
@@ -37,11 +37,11 @@ build_esplora_base_arm64:
 build_and_push_esplora_base:
   stage: build
   rules:
-    - if: $CI_COMMIT_BRANCH
+    - if: '$CI_PIPELINE_SOURCE == "push" && $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH'
       changes:
         paths:
           - contrib/Dockerfile.base
-        compare_to: master
+          - gitlab/build.yml
   variables:
     # No source checkout needed; we only tag already-built images.
     GIT_STRATEGY: none
@@ -73,14 +73,16 @@ build_and_push_esplora_base:
       --platform linux/${ARCH}
   script:
     - docker pull "${IMAGE_BASE}:latest-${ARCH}" || true
+    # Keep the test-only base local so parallel architectures cannot replace the shared manifest.
     - |
       docker buildx build \
-        --push \
+        --load \
         --platform "linux/${ARCH}" \
         -f contrib/Dockerfile.base \
         --build-arg BUILDKIT_INLINE_CACHE=1 \
         --cache-from "${IMAGE_BASE}:latest-${ARCH}" \
         -t "${IMAGE_BASE}:latest" .
+    - docker buildx use default
     # Now, build the esplora image
     - docker pull ${IMAGE}:latest-${ARCH} || true
     - docker compose -f contrib/docker-compose.yml up --build -d
@@ -115,6 +117,10 @@ build_esplora_test_arm64:
     - master
   except:
     - triggers
+  needs:
+    # Wait for a rebuilt multi-arch base when this push changes its inputs or CI flow.
+    - job: build_and_push_esplora_base
+      optional: true
   before_script:
     - echo "$DOCKERHUB_PASSWORD" | docker login -u $DOCKERHUB_USER --password-stdin
     - apk add --no-cache curl

--- a/gitlab/test.yml
+++ b/gitlab/test.yml
@@ -37,14 +37,16 @@
     - git clone -b "$GITHUB_PR_REF" "$GITHUB_REPO_URL" .
     # Make sure we test with the latest base image
     - docker pull "${IMAGE_BASE}:latest-${ARCH}" || true
+    # Keep the test-only base local so parallel architectures cannot replace the shared manifest.
     - |
       docker buildx build \
-        --push \
+        --load \
         --platform "linux/${ARCH}" \
         -f contrib/Dockerfile.base \
         --build-arg BUILDKIT_INLINE_CACHE=1 \
         --cache-from "${IMAGE_BASE}:latest-${ARCH}" \
         -t "${IMAGE_BASE}:latest" .
+    - docker buildx use default
     # Now, build the esplora image
     - docker pull ${IMAGE}:latest-${ARCH} || true
     - docker compose -f contrib/docker-compose.yml up --build -d


### PR DESCRIPTION
## Summary

- keep verification-only base images local to each CI job and switch Compose to the default dockerd builder
- publish official per-architecture base images only from default-branch push pipelines
- make master image builds wait for a rebuilt multi-arch base manifest when one is required
- allow a manual (web-run) default-branch pipeline to republish the bases and the multi-arch manifest

## Root cause

Both verification paths built a single platform but pushed it to the same `blockstream/esplora-base:latest` tag. The parallel jobs raced, and the last writer left a single-platform index. A later production build for the other architecture then failed with `no match for platform in manifest`.

`docker buildx build --load` now imports each verification result into the isolated Docker-in-Docker engine. Selecting the default builder afterward lets the subsequent Compose build resolve that local image without mutating the registry. Base publication moves to default-branch pushes; when base inputs or their CI flow change, the architecture builds are recomposed before the master images start.

Including `gitlab/build.yml` in the publication change set makes this merge rebuild both current bases and repair the shared manifest.

## Manual repair path

Branch pipelines evaluate the CI configuration of their own ref. A push to a stale pre-fix branch can therefore still replace the shared manifest with a single-platform image. A web-run pipeline on the default branch now rebuilds both bases and re-creates the manifest, so recovery is one click instead of a dummy commit.

## Validation

- `git diff --check`
- parsed all GitLab CI YAML with `yq`
- GitLab CI lint on the merged local configuration (re-run after the web-rule addition: valid, no errors)
- isolated Docker reproduction: the container builder could not resolve a dockerd-local base, then the default-builder switch let Compose consume it and build successfully
- confirmed against the failed master pipeline that the amd64 production build fails with `no match for platform in manifest`, and that mirror updates create `push`-source pipelines, which the new rules match

The current GitHub-to-GitLab trigger evaluates CI YAML from mirrored `master` and only clones the PR as build input, so its reported architecture checks do not execute this CI configuration diff.